### PR TITLE
CIS Benchmarks Plugin

### DIFF
--- a/cis-benchmarks/README.md
+++ b/cis-benchmarks/README.md
@@ -1,0 +1,30 @@
+# CIS Benchmarks
+
+This plugin utilizes the [kube-bench][kubebench] implementation of the [CIS security benchmarks][cis]. It is technically two plugins; one to run the checks on the master nodes and another to run the checks on the worker nodes.
+
+## Usage
+
+To run this plugin, run the following command:
+
+```
+sonobuoy run
+--plugin https://raw.githubusercontent.com/vmware-tanzu/sonobuoy-plugins/cis-benchmarks/cis-benchmarks/kube-bench-plugin.yaml --plugin https://raw.githubusercontent.com/vmware-tanzu/sonobuoy-plugins/cis-benchmarks/cis-benchmarks/kube-bench-master-plugin.yaml 
+```
+
+## Assumptions
+
+To run both plugins (with the command above) the following assumptions are made:
+
+ - One or more master node (with the label `node-role.kubernetes.io/master`)
+ - One or more worker node (without the master node label)
+ - Using Kubernetes 1.13+
+ - Sonobuoy 0.16.4 (relies on support for node affinity and the command above expects `--plugin` to take a URL)
+
+If you just want to run one or the other checks, specify only one of the plugins rather than both.
+
+## Customization
+
+Although you can run the plugins by specifying the URL for the YAML in this repository, you can also download the YAML and modify it if you need a custom mount or would like to specify other options to the kube-bench application.
+
+[kubebench]: https://github.com/aquasecurity/kube-bench
+[cis]: https://www.cisecurity.org/benchmark/kubernetes

--- a/cis-benchmarks/kube-bench-master-plugin.yaml
+++ b/cis-benchmarks/kube-bench-master-plugin.yaml
@@ -1,0 +1,61 @@
+podSpec:
+  containers: []
+  dnsPolicy: ClusterFirstWithHostNet
+  hostIPC: true
+  hostNetwork: true
+  hostPID: true
+  serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - operator: Exists
+  volumes:
+  - name: var-lib-etcd
+    hostPath:
+      path: "/var/lib/etcd"
+  - name: var-lib-kubelet
+    hostPath:
+      path: "/var/lib/kubelet"
+  - name: etc-systemd
+    hostPath:
+      path: "/etc/systemd"
+  - name: etc-kubernetes
+    hostPath:
+      path: "/etc/kubernetes"
+  - name: usr-bin
+    hostPath:
+      path: "/usr/bin"
+  affinity:
+    nodeAffinity: 
+      requiredDuringSchedulingIgnoredDuringExecution: 
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: node-role.kubernetes.io/master
+            operator: Exists
+sonobuoy-config:
+  driver: DaemonSet
+  plugin-name: kube-bench-master
+  result-format: junit
+spec:
+  command:
+  - /bin/sh
+  args:
+  - -c
+  - kube-bench master --version 1.13 --outputfile /tmp/results/output.xml --junit ; echo -n /tmp/results/output.xml > /tmp/results/done
+  image: schnake/kube-bench:v0.2.0-demo
+  name: plugin
+  resources: {}
+  volumeMounts:
+  - mountPath: /tmp/results
+    name: results
+  - name: var-lib-etcd
+    mountPath: /var/lib/etcd
+  - name: var-lib-kubelet
+    mountPath: /var/lib/kubelet
+  - name: etc-systemd
+    mountPath: /etc/systemd
+  - name: etc-kubernetes
+    mountPath: /etc/kubernetes
+    # /usr/bin is mounted to access kubectl / kubelet, for auto-detecting the Kubernetes version. 
+    # You can omit this mount if you specify --version as part of the command.           
+  - name: usr-bin
+    mountPath: /usr/bin
+

--- a/cis-benchmarks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/kube-bench-plugin.yaml
@@ -1,0 +1,61 @@
+podSpec:
+  containers: []
+  dnsPolicy: ClusterFirstWithHostNet
+  hostIPC: true
+  hostNetwork: true
+  hostPID: true
+  serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - operator: Exists
+  volumes:
+  - name: var-lib-etcd
+    hostPath:
+      path: "/var/lib/etcd"
+  - name: var-lib-kubelet
+    hostPath:
+      path: "/var/lib/kubelet"
+  - name: etc-systemd
+    hostPath:
+      path: "/etc/systemd"
+  - name: etc-kubernetes
+    hostPath:
+      path: "/etc/kubernetes"
+  - name: usr-bin
+    hostPath:
+      path: "/usr/bin"
+  affinity:
+    nodeAffinity: 
+      requiredDuringSchedulingIgnoredDuringExecution: 
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: node-role.kubernetes.io/master
+            operator: DoesNotExist
+sonobuoy-config:
+  driver: DaemonSet
+  plugin-name: kube-bench-node
+  result-format: junit
+spec:
+  command:
+  - /bin/sh
+  args:
+  - -c
+  - kube-bench --version 1.13 --outputfile /tmp/results/output.xml --junit ; echo -n /tmp/results/output.xml > /tmp/results/done
+  image: schnake/kube-bench:v0.2.0-demo
+  name: plugin
+  resources: {}
+  volumeMounts:
+  - mountPath: /tmp/results
+    name: results
+  - name: var-lib-etcd
+    mountPath: /var/lib/etcd
+  - name: var-lib-kubelet
+    mountPath: /var/lib/kubelet
+  - name: etc-systemd
+    mountPath: /etc/systemd
+  - name: etc-kubernetes
+    mountPath: /etc/kubernetes
+    # /usr/bin is mounted to access kubectl / kubelet, for auto-detecting the Kubernetes version. 
+    # You can omit this mount if you specify --version as part of the command.           
+  - name: usr-bin
+    mountPath: /usr/bin
+


### PR DESCRIPTION
Currently publishing this and targeting a demo build I created myself
from the kube-bench. This is just so that we can publish this for
visibility while kube-bench finalizes pushing their v0.2.0 image.

That release/image is necessary so that it supports the junit output
which makes it nicer for Sonobuoy post-processing.

The main podSpec options for this were taken from the job.yaml file
in the aquasecurity/kube-bench repo. Various differences in cluster
settings/deployment method may require these to be tweaked slightly.

As people try out the plugin we will probably find ways to improve
the plugin so that it can support a wider array of clusters successfully.

Signed-off-by: John Schnake <jschnake@vmware.com>