### PR TITLE
Updates the plugin to use the kube-bench v0.2.1

### DIFF
--- a/cis-benchmarks/kube-bench-master-plugin.yaml
+++ b/cis-benchmarks/kube-bench-master-plugin.yaml
@@ -40,7 +40,7 @@ spec:
   args:
   - -c
   - kube-bench master --version 1.13 --outputfile /tmp/results/output.xml --junit ; echo -n /tmp/results/output.xml > /tmp/results/done
-  image: schnake/kube-bench:v0.2.0-demo
+  image: aquasec/kube-bench:0.2.1
   name: plugin
   resources: {}
   volumeMounts:

--- a/cis-benchmarks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/kube-bench-plugin.yaml
@@ -40,7 +40,7 @@ spec:
   args:
   - -c
   - kube-bench --version 1.13 --outputfile /tmp/results/output.xml --junit ; echo -n /tmp/results/output.xml > /tmp/results/done
-  image: schnake/kube-bench:v0.2.0-demo
+  image: aquasec/kube-bench:0.2.1
   name: plugin
   resources: {}
   volumeMounts:


### PR DESCRIPTION
Originally targeting a demo build of v0.2.0, the upstream has
released two versions relatively quickly and can be used now.

The limiting factor, when originally released, was needing v0.2.0
to have the --junit flag which is now supported.

Signed-off-by: John Schnake <jschnake@vmware.com>