### PR TITLE
Bump version of systemd-logs for new push to dockerhub

### DIFF
--- a/systemd-logs/Makefile
+++ b/systemd-logs/Makefile
@@ -21,7 +21,7 @@ REGISTRY ?= sonobuoy
 IMAGE = $(REGISTRY)/$(TARGET)
 DOCKER ?= docker
 DIR := ${CURDIR}
-VERSION ?= v0.2
+VERSION ?= v0.3
 
 ARCH    ?= amd64
 LINUX_ARCHS = amd64 arm64 ppc64le


### PR DESCRIPTION
Nothing really content changed but since we are pushing to a new
registry and have updated the makefile; we should bump the version
so we dont have a sha mismatch between the different "v0.2" versions.

Signed-off-by: John Schnake <jschnake@vmware.com>