### PR TITLE
Add sleep at the end of kube-bench to avoid restart

### DIFF
--- a/cis-benchmarks/kube-bench-master-plugin.yaml
+++ b/cis-benchmarks/kube-bench-master-plugin.yaml
@@ -39,7 +39,7 @@ spec:
   - /bin/sh
   args:
   - -c
-  - kube-bench master --version 1.13 --outputfile /tmp/results/output.xml --junit ; echo -n /tmp/results/output.xml > /tmp/results/done
+  - kube-bench master --version 1.13 --outputfile /tmp/results/output.xml --junit ; echo -n /tmp/results/output.xml > /tmp/results/done ; while true; do echo "Sleeping for 1h to avoid daemonset restart"; sleep 3600; done
   image: aquasec/kube-bench:0.2.1
   name: plugin
   resources: {}

--- a/cis-benchmarks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/kube-bench-plugin.yaml
@@ -39,7 +39,7 @@ spec:
   - /bin/sh
   args:
   - -c
-  - kube-bench --version 1.13 --outputfile /tmp/results/output.xml --junit ; echo -n /tmp/results/output.xml > /tmp/results/done
+  - kube-bench --version 1.13 --outputfile /tmp/results/output.xml --junit ; echo -n /tmp/results/output.xml > /tmp/results/done ; while true; do echo "Sleeping for 1h to avoid daemonset restart"; sleep 3600; done
   image: aquasec/kube-bench:0.2.1
   name: plugin
   resources: {}


### PR DESCRIPTION
Run as a daemonset, the restart policy is Always by mandate. As
a result, the kubelet sees the plugin completion as a call to restart
it. This leads to confusing messages/state in the logs because the
container ends up in a crashbackoffloop.

This PR just adds a sleep similar to how the systemd-logs plugin
does.

Fixes #10

Signed-off-by: John Schnake <jschnake@vmware.com>

** NOTE **

I also considered making the plugin itself an init container which would run to completion before the sonobuoy-worker starts. That added some complication because at various points in the code there are no plugins (so validation has a problem) but even after solving that I ran into problems where it seemed like the initContainer would run (I could see log output) but no data was being generated. As a result, I felt this simple solution was best for the time being.