### PR TITLE
Add CIS plugin support for Enterprise PKS

### DIFF
--- a/cis-benchmarks/Dockerfile
+++ b/cis-benchmarks/Dockerfile
@@ -1,3 +1,5 @@
 FROM aquasec/kube-bench:0.2.3
 
+COPY entpks/config.yaml cfg/entpks.yaml
+
 COPY run-kube-bench.sh /run-kube-bench.sh

--- a/cis-benchmarks/README.md
+++ b/cis-benchmarks/README.md
@@ -35,6 +35,10 @@ For all of the environment described below, they can be set by modifying the val
 ### Environment variable options
 * `KUBERNETES_VERSION`
   This can be set to specify the Kubernetes version of your cluster. This is used to determine which version of the CIS benchmark kube-bench will run.
+* `DISTRIBUTION`
+  This can be set if the default configuration for kube-bench is not compatible with the Kubernetes distribution you are using.
+  By setting this value, a distribution specific configuration will be used when running kube-bench.
+  Currently, the only distribution that is supported is [Enterprise PKS (`entpks`)](./entpks).
 
 The following environment variables should only be modified if your cluster is Kubernetes v1.15+ and as such will be running version 1.5 of the CIS benchmark.
 The default settings for these environment variables are compatible with all versions of the benchmark.
@@ -56,6 +60,16 @@ Each of targets can be enabled or disabled by setting the value for the appropri
 * `TARGET_POLICIES`
   Setting this to "true" enables the checks for Kubernetes policies. For CIS 1.5, this is Section 2. This target cannot be enabled for earlier versions of the benchmark.
   This is disabled by default in both plugins.
+
+## Distribution specific support
+
+Some Kubernetes distributions require custom configurations to be provided in order to run kube-bench correctly.
+To perform the checks listed in the CIS benchmark, it is necessary for kube-bench to know the locations on disk of various Kubernetes configuration files.
+If the paths for a distribution's configuration files are not included in the list of [default locations](https://github.com/aquasecurity/kube-bench/blob/master/cfg/config.yaml), these must be provided via the kube-bench configuration.
+
+This plugin will include custom configuration for different distributions.
+Currently, only Enterprise PKS is supported as a custom distribution.
+If a custom distribution is not specified as described above, the default configuration for kube-bench will be used.
 
 ## Assumptions
 

--- a/cis-benchmarks/entpks/README.md
+++ b/cis-benchmarks/entpks/README.md
@@ -1,0 +1,13 @@
+# CIS Benchmark for Enterprise PKS
+
+This directory contains an adapted version of the CIS Benchmark plugin to be used with Enterprise PKS.
+This includes both the plugin definition and a customized configuration to be used with kube-bench that details where the configuration files for each of the components can be found.
+
+Enterprise PKS does not support running workloads on master nodes within a cluster.
+Given that Sonobuoy runs its plugins as Pods or DaemonSets, it is not possible to run the "kube-bench-master" plugin.
+Only the plugin for running on worker nodes is provided here.
+However, if you wish to run the CIS benchmark on your master nodes, you can still make use of the custom configuration that is provided within this directory.
+
+To do this, you will need to be able to SSH into your master nodes and download the [latest release of kube-bench](https://github.com/aquasecurity/kube-bench/releases).
+You will also need to either clone this repository, or download the [config.yaml](./config.yaml) file.
+Once you have installed the tool, follow the [instructions for running kube-bench](https://github.com/aquasecurity/kube-bench#running-kube-bench), and provide the custom configuration file using the `--config <path-to-custom-config>` flag.

--- a/cis-benchmarks/entpks/config.yaml
+++ b/cis-benchmarks/entpks/config.yaml
@@ -1,0 +1,93 @@
+---
+master:
+  components:
+    - apiserver
+    - scheduler
+    - controllermanager
+    - etcd
+    - flanneld
+    - kubernetes
+
+  kubernetes:
+    defaultconf: /etc/kubernetes/config
+
+  apiserver:
+    bins:
+      - "kube-apiserver"
+
+  scheduler:
+    bins:
+      - "kube-scheduler"
+
+  controllermanager:
+    bins:
+      - "kube-controller-manager"
+
+  etcd:
+    optional: true
+    bins:
+      - "etcd"
+    confs:
+      - /var/vcap/jobs/etcd/config/bpm.yml
+
+  flanneld:
+    optional: true
+    bins:
+      - flanneld
+
+node:
+  components:
+    - kubelet
+    - proxy
+    - kubernetes
+
+  kubernetes:
+    defaultconf: /etc/kubernetes/config
+
+  kubelet:
+    cafile:
+      - /var/vcap/jobs/kubelet/config/kubelet-client-ca.pem
+    bins:
+      - "kubelet"
+    kubeconfig:
+      - /var/vcap/jobs/kubelet/config/kubeconfig
+    confs:
+      - /var/vcap/jobs/kubelet/config/kubeletconfig.yml
+
+  proxy:
+    bins:
+      - "kube-proxy"
+    confs:
+      - /var/vcap/jobs/kube-proxy/config/config.yml
+    kubeconfig:
+      - /var/vcap/jobs/kube-proxy/config/kubeconfig
+
+etcd:
+  components:
+    - etcd
+
+  etcd:
+    bins:
+      - "etcd"
+    confs:
+      - /var/vcap/jobs/etcd/config/bpm.yml
+
+controlplane:
+  components: []
+
+policies:
+  components: []
+
+managedservices:
+  components: []
+
+version_mapping:
+  "1.11": "cis-1.3"
+  "1.12": "cis-1.3"
+  "1.13": "cis-1.4"
+  "1.14": "cis-1.4"
+  "1.15": "cis-1.5"
+  "1.16": "cis-1.5"
+  "1.17": "cis-1.5"
+  "ocp-3.10": "rh-0.7"
+  "ocp-3.11": "rh-0.7"

--- a/cis-benchmarks/entpks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/entpks/kube-bench-plugin.yaml
@@ -1,0 +1,71 @@
+podSpec:
+  containers: []
+  dnsPolicy: ClusterFirstWithHostNet
+  hostIPC: true
+  hostNetwork: true
+  hostPID: true
+  serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - operator: Exists
+  volumes:
+  - name: var-vcap-jobs
+    hostPath:
+      path: "/var/vcap/jobs"
+  - name: var-vcap-data
+    hostPath:
+      path: "/var/vcap/data"
+  - name: etc-kubernetes
+    hostPath:
+      path: "/etc/kubernetes"
+  # Uncomment this volume definition if you wish to use Kubernetes version auto-detection in kube-bench.
+  # - name: usr-bin
+  #   hostPath:
+  #     path: "/usr/bin"
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: node-role.kubernetes.io/master
+            operator: DoesNotExist
+sonobuoy-config:
+  driver: DaemonSet
+  plugin-name: kube-bench-node
+  result-format: junit
+spec:
+  command:
+  - /bin/sh
+  args:
+  - -c
+  - /run-kube-bench.sh; while true; do echo "Sleeping for 1h to avoid daemonset restart"; /bin/sleep 3600; done
+  env:
+    - name: KUBERNETES_VERSION
+      value: "1.17"
+    - name: TARGET_MASTER
+      value: "false"
+    - name: TARGET_NODE
+      value: "true"
+    - name: TARGET_CONTROLPLANE
+      value: "false"
+    - name: TARGET_ETCD
+      value: "false"
+    - name: TARGET_POLICIES
+      value: "false"
+    - name: DISTRIBUTION
+      value: "entpks"
+  image: sonobuoy/kube-bench:0.2.3
+  name: plugin
+  resources: {}
+  volumeMounts:
+  - mountPath: /tmp/results
+    name: results
+  - name: var-vcap-jobs
+    mountPath: /var/vcap/jobs
+  - name: var-vcap-data
+    mountPath: /var/vcap/data
+  - name: etc-kubernetes
+    mountPath: /etc/kubernetes
+  # /usr/bin is mounted to access kubectl / kubelet, used by kube-bench for auto-detecting the Kubernetes version.
+  # You can omit this mount if you provide the version using the KUBERNETES_VERSION environment variable.
+  # - name: usr-bin
+  #   mountPath: /usr/bin

--- a/cis-benchmarks/run-kube-bench.sh
+++ b/cis-benchmarks/run-kube-bench.sh
@@ -18,15 +18,19 @@
 set -o errexit
 
 # Return the config file to be used by kube-bench.
-# This will be expanded in future to accommodate custom configurations
-# for different providers.
+# If the specified distribution is supported, the path to a custom
+# configuration file will be returned. If not, the default configuration
+# is used.
 get_config() {
     # Assume default config path of cfg/config.yaml which is relative
     # to the workdir set in base image.
     local config="cfg/config.yaml"
 
-    case $PROVIDER in
-        # We will add custom configurations for different providers here.
+    case $DISTRIBUTION in
+        # We will add custom configurations for different distributions here.
+        "entpks")
+            config="cfg/entpks.yaml"
+            ;;
         "")
             # If unset, use default config file.
             ;;


### PR DESCRIPTION
This adds Enterprise PKS specific support for the CIS benchmark. This
is required as Enterprise PKS uses different locations for various
configuration files which are not included within the standard
kube-bench configuration. Due to the fact that workloads cannot be run
on master nodes of Enterprise PKS clusters, only the worker node version
of the plugin has been provided.

It also renames the environment variable `PROVIDER` to `DISTRIBUTION`
and documents how to use this variable as it was previously unused.

As the configuration for kube-bench exists as a file on disk, the
configuration file for this version is added to the existing custom
image provided by the Sonobuoy team for running kube-bench.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>