### PR TITLE
Upgrade to latest version of kube-bench

### DIFF
--- a/cis-benchmarks/Dockerfile
+++ b/cis-benchmarks/Dockerfile
@@ -1,0 +1,3 @@
+FROM aquasec/kube-bench:0.2.3
+
+COPY run-kube-bench.sh /run-kube-bench.sh

--- a/cis-benchmarks/README.md
+++ b/cis-benchmarks/README.md
@@ -4,11 +4,58 @@ This plugin utilizes the [kube-bench][kubebench] implementation of the [CIS secu
 
 ## Usage
 
-To run this plugin, run the following command:
+To run this plugin with the default options, run the following command:
 
 ```
 sonobuoy run --plugin https://raw.githubusercontent.com/vmware-tanzu/sonobuoy-plugins/master/cis-benchmarks/kube-bench-plugin.yaml --plugin https://raw.githubusercontent.com/vmware-tanzu/sonobuoy-plugins/master/cis-benchmarks/kube-bench-master-plugin.yaml
 ```
+
+The version of the CIS benchmark you should run depends on the version of your Kubernetes cluster.
+The Kubernetes version can be set explicitly when running kube-bench or kube-bench can auto-detect the version if you mount `kubectl` or `kubelet` into the container running it.
+
+By default, this plugin explicitly sets the version and assumes you are running Kubernetes 1.17.
+You can modify this and set the version when running by setting the `KUBERNETES_VERSION` environment variable for each of the two plugins by adding the following flags:
+`--plugin-env kube-bench-master.KUBERNETES_VERSION=<version> --plugin-env kube-bench-node.KUBERNETES_VERSION=<version>`.
+You can also download and modify the plugin YAML definitions directly.
+
+If you wish to the use the Kubernetes version auto-detection feature, you must uncomment the [volume definition](./kube-bench-master-plugin.yaml#L24-L26) and [volume mount](./kube-bench-master-plugin.yaml#L73-L74) in both plugin definitions.
+This will result in the `/usr/bin` directory on the nodes being mounted into the container.
+
+**NOTE**: Some users have experienced issues when using this approach.
+This has been fixed in kube-bench however hasn't been released yet.
+For simplicity, we recommend specifying the version explicitly using the instructions above.
+
+## Plugin options
+
+The plugin can be configured by setting a number of options using environment variables.
+For all of the environment described below, they can be set by modifying the value in the plugin YAML, or can be set using Sonobuoy's `--plugin-env` flag as follows:
+* `--plugin-env kube-bench-master.ENV_VAR=<value>` for the kube-bench-master plugin, or
+* `--plugin-env kube-bench-node.ENV_VAR=<value>` for the kube-bench-node plugin
+
+### Environment variable options
+* `KUBERNETES_VERSION`
+  This can be set to specify the Kubernetes version of your cluster. This is used to determine which version of the CIS benchmark kube-bench will run.
+
+The following environment variables should only be modified if your cluster is Kubernetes v1.15+ and as such will be running version 1.5 of the CIS benchmark.
+The default settings for these environment variables are compatible with all versions of the benchmark.
+CIS 1.5 introduces a number of new targets to run checks for rather than just the master and node targets.
+Each of targets can be enabled or disabled by setting the value for the appropriate variable to "true" or "false".
+
+* `TARGET_MASTER`
+  Setting this to "true" enables the checks for master nodes. For all versions of the CIS benchmark, this is Section 1.
+  This is enabled by default in the kube-bench-master plugin.
+* `TARGET_NODE`
+  Setting this to "true" enables the checks for worker nodes. For CIS 1.5, this is Section 4. For all other versions of the CIS benchmark, this is Section 2.
+  This is enabled by default in the kube-bench-node plugin.
+* `TARGET_ETCD`
+  Setting this to "true" enables the checks for etcd configuration. For CIS 1.5, this is Section 2. This target cannot be enabled for earlier versions of the benchmark.
+  This is disabled by default in both plugins.
+* `TARGET_CONTROLPLANE`
+  Setting this to "true" enables the checks for control plane configuration. For CIS 1.5, this is Section 3. This target cannot be enabled for earlier versions of the benchmark.
+  This is disabled by default in both plugins.
+* `TARGET_POLICIES`
+  Setting this to "true" enables the checks for Kubernetes policies. For CIS 1.5, this is Section 2. This target cannot be enabled for earlier versions of the benchmark.
+  This is disabled by default in both plugins.
 
 ## Assumptions
 
@@ -16,7 +63,6 @@ To run both plugins (with the command above) the following assumptions are made:
 
  - One or more master node (with the label `node-role.kubernetes.io/master`)
  - One or more worker node (without the master node label)
- - Using Kubernetes 1.13+
  - Sonobuoy 0.16.4 (relies on support for node affinity and the command above expects `--plugin` to take a URL)
 
 If you just want to run one or the other checks, specify only one of the plugins rather than both.

--- a/cis-benchmarks/kube-bench-master-plugin.yaml
+++ b/cis-benchmarks/kube-bench-master-plugin.yaml
@@ -20,9 +20,10 @@ podSpec:
   - name: etc-kubernetes
     hostPath:
       path: "/etc/kubernetes"
-  - name: usr-bin
-    hostPath:
-      path: "/usr/bin"
+  # Uncomment this volume definition if you wish to use Kubernetes version auto-detection in kube-bench.
+  # - name: usr-bin
+  #   hostPath:
+  #     path: "/usr/bin"
   affinity:
     nodeAffinity: 
       requiredDuringSchedulingIgnoredDuringExecution: 
@@ -39,8 +40,21 @@ spec:
   - /bin/sh
   args:
   - -c
-  - kube-bench master --version 1.13 --outputfile /tmp/results/output.xml --junit ; echo -n /tmp/results/output.xml > /tmp/results/done ; while true; do echo "Sleeping for 1h to avoid daemonset restart"; sleep 3600; done
-  image: aquasec/kube-bench:0.2.1
+  - /run-kube-bench.sh; while true; do echo "Sleeping for 1h to avoid daemonset restart"; sleep 3600; done
+  env:
+    - name: KUBERNETES_VERSION
+      value: "1.17"
+    - name: TARGET_MASTER
+      value: "true"
+    - name: TARGET_NODE
+      value: "false"
+    - name: TARGET_CONTROLPLANE
+      value: "false"
+    - name: TARGET_ETCD
+      value: "false"
+    - name: TARGET_POLICIES
+      value: "false"
+  image: sonobuoy/kube-bench:0.2.3
   name: plugin
   resources: {}
   volumeMounts:
@@ -54,8 +68,8 @@ spec:
     mountPath: /etc/systemd
   - name: etc-kubernetes
     mountPath: /etc/kubernetes
-    # /usr/bin is mounted to access kubectl / kubelet, for auto-detecting the Kubernetes version. 
-    # You can omit this mount if you specify --version as part of the command.           
-  - name: usr-bin
-    mountPath: /usr/bin
+  # /usr/bin is mounted to access kubectl / kubelet, used by kube-bench for auto-detecting the Kubernetes version.
+  # You can omit this mount if you provide the version using the KUBERNETES_VERSION environment variable.
+  # - name: usr-bin
+  #   mountPath: /usr/bin
 

--- a/cis-benchmarks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/kube-bench-plugin.yaml
@@ -20,9 +20,10 @@ podSpec:
   - name: etc-kubernetes
     hostPath:
       path: "/etc/kubernetes"
-  - name: usr-bin
-    hostPath:
-      path: "/usr/bin"
+  # Uncomment this volume definition if you wish to use Kubernetes version auto-detection in kube-bench.
+  # - name: usr-bin
+  #   hostPath:
+  #     path: "/usr/bin"
   affinity:
     nodeAffinity: 
       requiredDuringSchedulingIgnoredDuringExecution: 
@@ -39,8 +40,21 @@ spec:
   - /bin/sh
   args:
   - -c
-  - kube-bench --version 1.13 --outputfile /tmp/results/output.xml --junit ; echo -n /tmp/results/output.xml > /tmp/results/done ; while true; do echo "Sleeping for 1h to avoid daemonset restart"; sleep 3600; done
-  image: aquasec/kube-bench:0.2.1
+  - /run-kube-bench.sh; while true; do echo "Sleeping for 1h to avoid daemonset restart"; /bin/sleep 3600; done
+  env:
+    - name: KUBERNETES_VERSION
+      value: "1.17"
+    - name: TARGET_MASTER
+      value: "false"
+    - name: TARGET_NODE
+      value: "true"
+    - name: TARGET_CONTROLPLANE
+      value: "false"
+    - name: TARGET_ETCD
+      value: "false"
+    - name: TARGET_POLICIES
+      value: "false"
+  image: sonobuoy/kube-bench:0.2.3
   name: plugin
   resources: {}
   volumeMounts:
@@ -54,8 +68,8 @@ spec:
     mountPath: /etc/systemd
   - name: etc-kubernetes
     mountPath: /etc/kubernetes
-    # /usr/bin is mounted to access kubectl / kubelet, for auto-detecting the Kubernetes version. 
-    # You can omit this mount if you specify --version as part of the command.           
-  - name: usr-bin
-    mountPath: /usr/bin
+  # /usr/bin is mounted to access kubectl / kubelet, used by kube-bench for auto-detecting the Kubernetes version. 
+  # You can omit this mount if you provide the version using the KUBERNETES_VERSION environment variable.           
+  # - name: usr-bin
+  #   mountPath: /usr/bin
 

--- a/cis-benchmarks/run-kube-bench.sh
+++ b/cis-benchmarks/run-kube-bench.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+
+##########################################################################
+# Copyright the Sonobuoy contributors 2020
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+
+# Return the config file to be used by kube-bench.
+# This will be expanded in future to accommodate custom configurations
+# for different providers.
+get_config() {
+    # Assume default config path of cfg/config.yaml which is relative
+    # to the workdir set in base image.
+    local config="cfg/config.yaml"
+
+    case $PROVIDER in
+        # We will add custom configurations for different providers here.
+        "")
+            # If unset, use default config file.
+            ;;
+        *)
+            ;;
+    esac
+
+    echo $config
+}
+
+# Return the version flag with the version if specified. This enables users
+# to still use the version auto-detect feature if needed.
+get_version_flag() {
+    local version_flag=""
+
+    if [ -n "$KUBERNETES_VERSION" ]; then
+        version_flag="--version $KUBERNETES_VERSION"
+    fi
+
+    echo $version_flag
+}
+
+# Return a space separated list of targets to provide to kube-bench.
+get_targets() {
+    local targets
+
+    if [ "$TARGET_MASTER" = true ]; then
+        targets="${targets} master"
+    fi
+
+    if [ "$TARGET_NODE" = true ]; then
+        targets="${targets} node"
+    fi
+
+    # Other targets are only compatible with kube-bench for Kubernetes 1.15 and later.
+    # We could prevent them from being added, however we may not always know the
+    # version being tested as the user may be relying on version being auto-detected.
+    if [ "$TARGET_CONTROLPLANE" = true ]; then
+        targets="${targets} controlplane"
+    fi
+
+    if [ "$TARGET_ETCD" = true ]; then
+        targets="${targets} etcd"
+    fi
+
+    if [ "$TARGET_POLICIES" = true ]; then
+        targets="${targets} policies"
+    fi
+
+    echo $targets
+}
+
+run_kube_bench() {
+    local config="$(get_config)"
+    local version_flag="$(get_version_flag)"
+    local targets="$(get_targets)"
+
+    for target in $targets; do
+        kube-bench --config $config run $version_flag --targets $target --outputfile /tmp/results/$target.xml --junit
+    done
+
+    tar czf /tmp/results/results.tar.gz /tmp/results/*.xml
+    echo -n /tmp/results/results.tar.gz > /tmp/results/done
+}
+
+run_kube_bench


### PR DESCRIPTION
This upgrades the version of kube-bench that we are using to latest
version, 0.2.3. This version includes support for CIS 1.15.

Several changes to the structure of the checks were introduced in thi
version, including the checks being separated into multiple "targets".
As a result, we would like to provide a way for the user to easily
customize which version and targets they run. This has been done by
introducing a small wrapper script which will check the value of
various plugin environment variables and call kube-bench accordingly.

To include this wrapper script, we need to provide our own version of
the kube-bench image with it included. This uses the Aqua Security image
as the base image and just adds the new script.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>