### PR TITLE
Add /lib/systemd volume mount

### DIFF
--- a/cis-benchmarks/kube-bench-master-plugin.yaml
+++ b/cis-benchmarks/kube-bench-master-plugin.yaml
@@ -14,6 +14,9 @@ podSpec:
   - name: var-lib-kubelet
     hostPath:
       path: "/var/lib/kubelet"
+  - name: lib-systemd
+    hostPath:
+      path: "/lib/systemd"
   - name: etc-systemd
     hostPath:
       path: "/etc/systemd"
@@ -66,6 +69,8 @@ spec:
     mountPath: /var/lib/kubelet
   - name: etc-systemd
     mountPath: /etc/systemd
+  - name: lib-systemd
+    mountPath: /lib/systemd
   - name: etc-kubernetes
     mountPath: /etc/kubernetes
   # /usr/bin is mounted to access kubectl / kubelet, used by kube-bench for auto-detecting the Kubernetes version.

--- a/cis-benchmarks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/kube-bench-plugin.yaml
@@ -14,6 +14,9 @@ podSpec:
   - name: var-lib-kubelet
     hostPath:
       path: "/var/lib/kubelet"
+  - name: lib-systemd
+    hostPath:
+      path: "/lib/systemd"
   - name: etc-systemd
     hostPath:
       path: "/etc/systemd"
@@ -64,6 +67,8 @@ spec:
     mountPath: /var/lib/etcd
   - name: var-lib-kubelet
     mountPath: /var/lib/kubelet
+  - name: lib-systemd
+    mountPath: /lib/systemd
   - name: etc-systemd
     mountPath: /etc/systemd
   - name: etc-kubernetes


### PR DESCRIPTION
Some of the config files that kube-bench looks for are within
/lib/systemd. This directory was not being mounted into the container so
some tests were failing since it could not access the files for the
checks. This change adds that volume.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>