### PR TITLE
Upgrade to kube-bench 0.3.0

### DIFF
--- a/cis-benchmarks/Dockerfile
+++ b/cis-benchmarks/Dockerfile
@@ -1,4 +1,4 @@
-FROM aquasec/kube-bench:0.2.3
+FROM aquasec/kube-bench:0.3.0
 
 COPY entpks/config.yaml cfg/entpks.yaml
 

--- a/cis-benchmarks/entpks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/entpks/kube-bench-plugin.yaml
@@ -53,7 +53,7 @@ spec:
       value: "false"
     - name: DISTRIBUTION
       value: "entpks"
-  image: sonobuoy/kube-bench:0.2.3
+  image: sonobuoy/kube-bench:0.3.0
   name: plugin
   resources: {}
   volumeMounts:
@@ -61,11 +61,16 @@ spec:
     name: results
   - name: var-vcap-jobs
     mountPath: /var/vcap/jobs
+    readOnly: true
   - name: var-vcap-data
     mountPath: /var/vcap/data
+    readOnly: true
   - name: etc-kubernetes
     mountPath: /etc/kubernetes
+    readOnly: true
   # /usr/bin is mounted to access kubectl / kubelet, used by kube-bench for auto-detecting the Kubernetes version.
+  # It is mounted at the path /usr/local/mount-from-host/bin to avoid overwriting /usr/bin within the container.
   # You can omit this mount if you provide the version using the KUBERNETES_VERSION environment variable.
   # - name: usr-bin
-  #   mountPath: /usr/bin
+  #   mountPath: /usr/local/mount-from-host/bin
+  #   readOnly: true

--- a/cis-benchmarks/kube-bench-master-plugin.yaml
+++ b/cis-benchmarks/kube-bench-master-plugin.yaml
@@ -57,7 +57,7 @@ spec:
       value: "false"
     - name: TARGET_POLICIES
       value: "false"
-  image: sonobuoy/kube-bench:0.2.3
+  image: sonobuoy/kube-bench:0.3.0
   name: plugin
   resources: {}
   volumeMounts:
@@ -65,16 +65,22 @@ spec:
     name: results
   - name: var-lib-etcd
     mountPath: /var/lib/etcd
+    readOnly: true
   - name: var-lib-kubelet
     mountPath: /var/lib/kubelet
+    readOnly: true
   - name: etc-systemd
     mountPath: /etc/systemd
+    readOnly: true
   - name: lib-systemd
     mountPath: /lib/systemd
+    readOnly: true
   - name: etc-kubernetes
     mountPath: /etc/kubernetes
-  # /usr/bin is mounted to access kubectl / kubelet, used by kube-bench for auto-detecting the Kubernetes version.
+    readOnly: true
+  # /usr/bin from the host is mounted to access kubectl / kubelet, used by kube-bench for auto-detecting the Kubernetes version.
+  # It is mounted at the path /usr/local/mount-from-host/bin to avoid overwriting /usr/bin within the container.
   # You can omit this mount if you provide the version using the KUBERNETES_VERSION environment variable.
   # - name: usr-bin
-  #   mountPath: /usr/bin
-
+  #   mountPath: /usr/local/mount-from-host/bin
+  #   readOnly: true

--- a/cis-benchmarks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/kube-bench-plugin.yaml
@@ -57,7 +57,7 @@ spec:
       value: "false"
     - name: TARGET_POLICIES
       value: "false"
-  image: sonobuoy/kube-bench:0.2.3
+  image: sonobuoy/kube-bench:0.3.0
   name: plugin
   resources: {}
   volumeMounts:
@@ -65,16 +65,23 @@ spec:
     name: results
   - name: var-lib-etcd
     mountPath: /var/lib/etcd
+    readOnly: true
   - name: var-lib-kubelet
     mountPath: /var/lib/kubelet
+    readOnly: true
   - name: lib-systemd
     mountPath: /lib/systemd
+    readOnly: true
   - name: etc-systemd
     mountPath: /etc/systemd
+    readOnly: true
   - name: etc-kubernetes
     mountPath: /etc/kubernetes
+    readOnly: true
   # /usr/bin is mounted to access kubectl / kubelet, used by kube-bench for auto-detecting the Kubernetes version. 
+  # It is mounted at the path /usr/local/mount-from-host/bin to avoid overwriting /usr/bin within the container.
   # You can omit this mount if you provide the version using the KUBERNETES_VERSION environment variable.           
   # - name: usr-bin
-  #   mountPath: /usr/bin
+  #   mountPath: /usr/local/mount-from-host/bin
+  #   readOnly: true
 


### PR DESCRIPTION
This change upgrades the base image we are using to
aquasec/kube-bench:0.3.0. As part of this upgrade, the plugin
definitions have been updated to incorporate improvements made in the
upstream job definitions.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>