### PR TITLE
Add support for GKE

### DIFF
--- a/cis-benchmarks/README.md
+++ b/cis-benchmarks/README.md
@@ -38,7 +38,7 @@ For all of the environment described below, they can be set by modifying the val
 * `DISTRIBUTION`
   This can be set if the default configuration for kube-bench is not compatible with the Kubernetes distribution you are using.
   By setting this value, a distribution specific configuration will be used when running kube-bench.
-  Currently, the only distribution that is supported is [Enterprise PKS (`entpks`)](./entpks).
+  The supported distributions are [Enterprise PKS (`entpks`)](./entpks) and [Google Kubernetes Engine (`gke`)](./gke).
 
 The following environment variables should only be modified if your cluster is Kubernetes v1.15+ and as such will be running version 1.5 of the CIS benchmark.
 The default settings for these environment variables are compatible with all versions of the benchmark.
@@ -60,6 +60,15 @@ Each of targets can be enabled or disabled by setting the value for the appropri
 * `TARGET_POLICIES`
   Setting this to "true" enables the checks for Kubernetes policies. For CIS 1.5, this is Section 2. This target cannot be enabled for earlier versions of the benchmark.
   This is disabled by default in both plugins.
+
+The following environment variables are distribution specific.
+They should not be enabled unless you are running against a distribution where they are valid and compatible.
+Enabling these when running against an unsupported distribution will result in the plugin failing to run correctly.
+
+* `TARGET_MANAGED_SERVICES`
+  Setting this to "true" enables the checks for managed service components.
+  This target is only available when running the [CIS GKE benchmark](./gke).
+  This is enabled by default for the GKE version of the plugin.
 
 ## Distribution specific support
 

--- a/cis-benchmarks/gke/README.md
+++ b/cis-benchmarks/gke/README.md
@@ -1,0 +1,14 @@
+# CIS Benchmark for Google Kubernetes Engine
+
+This directory contains an adapted version of the CIS Benchmark plugin to be used with Google Kubernetes Engine (GKE).
+Running the plugin on GKE does not require any additional configuration files, just the adapted plugin definition.
+
+GKE does not provide access to master nodes within a cluster.
+Due to this, it is not possible to run the "kube-bench-master" plugin.
+Only the plugin for running on worker nodes is provided here which runs the `node`, `policies`, and `managedservices` targets.
+
+Which version of the CIS benchmark to run depends on the version of your cluster.
+For clusters with a version lower than v1.15, the standard version of the CIS benchmark for that version should be used.
+For clusters where the version is v1.15 or later, the custom GKE benchmark should be used.
+The Sonobuoy plugin provided here will determine which benchmark to use based on the Kubernetes version provided.
+If the environment variable `KUBERNETES_VERSION` is not set, or is v1.15 or greater, the custom GKE benchmark will be run, otherwise, the benchmark matching the version will be run.

--- a/cis-benchmarks/gke/kube-bench-plugin.yaml
+++ b/cis-benchmarks/gke/kube-bench-plugin.yaml
@@ -1,0 +1,85 @@
+podSpec:
+  containers: []
+  dnsPolicy: ClusterFirstWithHostNet
+  hostIPC: true
+  hostNetwork: true
+  hostPID: true
+  serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - operator: Exists
+  volumes:
+  - name: var-lib-etcd
+    hostPath:
+      path: "/var/lib/etcd"
+  - name: var-lib-kubelet
+    hostPath:
+      path: "/var/lib/kubelet"
+  - name: etc-systemd
+    hostPath:
+      path: "/etc/systemd"
+  - name: etc-kubernetes
+    hostPath:
+      path: "/etc/kubernetes"
+  # Uncomment this volume definition if you wish to use Kubernetes version auto-detection in kube-bench.
+  # - name: usr-bin
+  #   hostPath:
+  #     path: "/usr/bin"
+  affinity:
+    nodeAffinity: 
+      requiredDuringSchedulingIgnoredDuringExecution: 
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: node-role.kubernetes.io/master
+            operator: DoesNotExist
+sonobuoy-config:
+  driver: DaemonSet
+  plugin-name: kube-bench-node
+  result-format: junit
+spec:
+  command:
+  - /bin/sh
+  args:
+  - -c
+  - /run-kube-bench.sh; while true; do echo "Sleeping for 1h to avoid daemonset restart"; /bin/sleep 3600; done
+  env:
+    - name: KUBERNETES_VERSION
+      value: "1.15"
+    - name: TARGET_MASTER
+      value: "false"
+    - name: TARGET_NODE
+      value: "true"
+    - name: TARGET_CONTROLPLANE
+      value: "false"
+    - name: TARGET_ETCD
+      value: "false"
+    - name: TARGET_POLICIES
+      value: "true"
+    - name: TARGET_MANAGED_SERVICES
+      value: "true"
+    - name: DISTRIBUTION
+      value: "gke"
+  image: sonobuoy/kube-bench:0.3.0
+  name: plugin
+  resources: {}
+  volumeMounts:
+  - mountPath: /tmp/results
+    name: results
+  - name: var-lib-etcd
+    mountPath: /var/lib/etcd
+    readOnly: true
+  - name: var-lib-kubelet
+    mountPath: /var/lib/kubelet
+    readOnly: true
+  - name: etc-systemd
+    mountPath: /etc/systemd
+    readOnly: true
+  - name: etc-kubernetes
+    mountPath: /etc/kubernetes
+    readOnly: true
+  # /usr/bin is mounted to access kubectl / kubelet, used by kube-bench for auto-detecting the Kubernetes version. 
+  # It is mounted at the path /usr/local/mount-from-host/bin to avoid overwriting /usr/bin within the container.
+  # You can omit this mount if you provide the version using the KUBERNETES_VERSION environment variable.           
+  # - name: lib-systemd
+  #   mountPath: /usr/local/mount-from-host/bin
+  #   readOnly: true
+


### PR DESCRIPTION
GKE v1.15+ clusters use a version of the CIS benchmark that is tailored
to GKE clusters. To use this, the flag `--benchmark` needs to be passed
to kube-bench rather than `--version`. This updates the script that runs
kube-bench to check for the GKE distribution. If the Kubernetes version
is set and is less than 1.15, it defaults to the original `--version`
flag, otherwise it assumes `--benchmark gke-1.0` should be used.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>