### PR TITLE
Add support for EKS CIS Benchmark

### DIFF
--- a/cis-benchmarks/Dockerfile
+++ b/cis-benchmarks/Dockerfile
@@ -1,4 +1,4 @@
-FROM aquasec/kube-bench:0.3.0
+FROM aquasec/kube-bench:0.3.1
 
 COPY entpks/config.yaml cfg/entpks.yaml
 

--- a/cis-benchmarks/README.md
+++ b/cis-benchmarks/README.md
@@ -67,8 +67,8 @@ Enabling these when running against an unsupported distribution will result in t
 
 * `TARGET_MANAGED_SERVICES`
   Setting this to "true" enables the checks for managed service components.
-  This target is only available when running the [CIS GKE benchmark](./gke) or the [CIS EKS benchmark](./eks).
-  This is enabled by default for the GKE and EKS versions of the plugin.
+  This target is only available when running the [CIS GKE benchmark](./gke).
+  This is enabled by default for the GKE version of the plugin.
 
 ## Distribution specific support
 

--- a/cis-benchmarks/README.md
+++ b/cis-benchmarks/README.md
@@ -38,7 +38,7 @@ For all of the environment described below, they can be set by modifying the val
 * `DISTRIBUTION`
   This can be set if the default configuration for kube-bench is not compatible with the Kubernetes distribution you are using.
   By setting this value, a distribution specific configuration will be used when running kube-bench.
-  The supported distributions are [Enterprise PKS (`entpks`)](./entpks) and [Google Kubernetes Engine (`gke`)](./gke).
+  The supported distributions are [Enterprise PKS (`entpks`)](./entpks), [Google Kubernetes Engine (`gke`)](./gke) and [Elastic Kubernetes Service (`eks)](./eks).
 
 The following environment variables should only be modified if your cluster is Kubernetes v1.15+ and as such will be running version 1.5 of the CIS benchmark.
 The default settings for these environment variables are compatible with all versions of the benchmark.
@@ -67,8 +67,8 @@ Enabling these when running against an unsupported distribution will result in t
 
 * `TARGET_MANAGED_SERVICES`
   Setting this to "true" enables the checks for managed service components.
-  This target is only available when running the [CIS GKE benchmark](./gke).
-  This is enabled by default for the GKE version of the plugin.
+  This target is only available when running the [CIS GKE benchmark](./gke) or the [CIS EKS benchmark](./eks).
+  This is enabled by default for the GKE and EKS versions of the plugin.
 
 ## Distribution specific support
 

--- a/cis-benchmarks/eks/README.md
+++ b/cis-benchmarks/eks/README.md
@@ -5,7 +5,8 @@ Running the plugin on EKS does not require any additional configuration files, j
 
 EKS does not provide access to master nodes within a cluster.
 Due to this, it is not possible to run the "kube-bench-master" plugin.
-Only the plugin for running on worker nodes is provided here which runs the `node`, `policies`, and `managedservices` targets.
+Only the plugin for running on worker nodes is provided here which runs the `node` target.
+The `policies` and `managedservices` targets will be added once [aquasecurity/kube-bench#644](https://github.com/aquasecurity/kube-bench/issues/644) is resolved.
 
 Which version of the CIS benchmark to run depends on the version of your cluster.
 For clusters with a version lower than v1.15, the standard version of the CIS benchmark for that version should be used.

--- a/cis-benchmarks/eks/README.md
+++ b/cis-benchmarks/eks/README.md
@@ -1,0 +1,14 @@
+# CIS Benchmark for Elastic Kubernetes Service
+
+This directory contains an adapted version of the CIS Benchmark plugin to be used with Elastic Kubernetes Service (EKS).
+Running the plugin on EKS does not require any additional configuration files, just the adapted plugin definition.
+
+EKS does not provide access to master nodes within a cluster.
+Due to this, it is not possible to run the "kube-bench-master" plugin.
+Only the plugin for running on worker nodes is provided here which runs the `node`, `policies`, and `managedservices` targets.
+
+Which version of the CIS benchmark to run depends on the version of your cluster.
+For clusters with a version lower than v1.15, the standard version of the CIS benchmark for that version should be used.
+For clusters where the version is v1.15 or later, the custom EKS benchmark should be used.
+The Sonobuoy plugin provided here will determine which benchmark to use based on the Kubernetes version provided.
+If the environment variable `KUBERNETES_VERSION` is not set, or is v1.15 or greater, the custom EKS benchmark will be run, otherwise, the benchmark matching the version will be run.

--- a/cis-benchmarks/eks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/eks/kube-bench-plugin.yaml
@@ -6,20 +6,20 @@ podSpec:
   hostPID: true
   serviceAccountName: sonobuoy-serviceaccount
   tolerations:
-  - operator: Exists
+    - operator: Exists
   volumes:
-  - name: var-lib-etcd
-    hostPath:
-      path: "/var/lib/etcd"
-  - name: var-lib-kubelet
-    hostPath:
-      path: "/var/lib/kubelet"
-  - name: etc-systemd
-    hostPath:
-      path: "/etc/systemd"
-  - name: etc-kubernetes
-    hostPath:
-      path: "/etc/kubernetes"
+    - name: var-lib-etcd
+      hostPath:
+        path: "/var/lib/etcd"
+    - name: var-lib-kubelet
+      hostPath:
+        path: "/var/lib/kubelet"
+    - name: etc-systemd
+      hostPath:
+        path: "/etc/systemd"
+    - name: etc-kubernetes
+      hostPath:
+        path: "/etc/kubernetes"
   # Uncomment this volume definition if you wish to use Kubernetes version auto-detection in kube-bench.
   # - name: usr-bin
   #   hostPath:
@@ -28,19 +28,19 @@ podSpec:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
-        - matchExpressions:
-          - key: node-role.kubernetes.io/master
-            operator: DoesNotExist
+          - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
 sonobuoy-config:
   driver: DaemonSet
   plugin-name: kube-bench-node
   result-format: junit
 spec:
   command:
-  - /bin/sh
+    - /bin/sh
   args:
-  - -c
-  - /run-kube-bench.sh; while true; do echo "Sleeping for 1h to avoid daemonset restart"; /bin/sleep 3600; done
+    - -c
+    - /run-kube-bench.sh; while true; do echo "Sleeping for 1h to avoid daemonset restart"; /bin/sleep 3600; done
   env:
     - name: KUBERNETES_VERSION
       value: "1.15"
@@ -53,29 +53,29 @@ spec:
     - name: TARGET_ETCD
       value: "false"
     - name: TARGET_POLICIES
-      value: "true"
+      value: "false"
     - name: TARGET_MANAGED_SERVICES
-      value: "true"
+      value: "false"
     - name: DISTRIBUTION
       value: "eks"
   image: sonobuoy/kube-bench:0.3.1
   name: plugin
   resources: {}
   volumeMounts:
-  - mountPath: /tmp/results
-    name: results
-  - name: var-lib-etcd
-    mountPath: /var/lib/etcd
-    readOnly: true
-  - name: var-lib-kubelet
-    mountPath: /var/lib/kubelet
-    readOnly: true
-  - name: etc-systemd
-    mountPath: /etc/systemd
-    readOnly: true
-  - name: etc-kubernetes
-    mountPath: /etc/kubernetes
-    readOnly: true
+    - mountPath: /tmp/results
+      name: results
+    - name: var-lib-etcd
+      mountPath: /var/lib/etcd
+      readOnly: true
+    - name: var-lib-kubelet
+      mountPath: /var/lib/kubelet
+      readOnly: true
+    - name: etc-systemd
+      mountPath: /etc/systemd
+      readOnly: true
+    - name: etc-kubernetes
+      mountPath: /etc/kubernetes
+      readOnly: true
   # /usr/bin is mounted to access kubectl / kubelet, used by kube-bench for auto-detecting the Kubernetes version.
   # It is mounted at the path /usr/local/mount-from-host/bin to avoid overwriting /usr/bin within the container.
   # You can omit this mount if you provide the version using the KUBERNETES_VERSION environment variable.

--- a/cis-benchmarks/eks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/eks/kube-bench-plugin.yaml
@@ -8,12 +8,15 @@ podSpec:
   tolerations:
   - operator: Exists
   volumes:
-  - name: var-vcap-jobs
+  - name: var-lib-etcd
     hostPath:
-      path: "/var/vcap/jobs"
-  - name: var-vcap-data
+      path: "/var/lib/etcd"
+  - name: var-lib-kubelet
     hostPath:
-      path: "/var/vcap/data"
+      path: "/var/lib/kubelet"
+  - name: etc-systemd
+    hostPath:
+      path: "/etc/systemd"
   - name: etc-kubernetes
     hostPath:
       path: "/etc/kubernetes"
@@ -40,7 +43,7 @@ spec:
   - /run-kube-bench.sh; while true; do echo "Sleeping for 1h to avoid daemonset restart"; /bin/sleep 3600; done
   env:
     - name: KUBERNETES_VERSION
-      value: "1.17"
+      value: "1.15"
     - name: TARGET_MASTER
       value: "false"
     - name: TARGET_NODE
@@ -50,20 +53,25 @@ spec:
     - name: TARGET_ETCD
       value: "false"
     - name: TARGET_POLICIES
-      value: "false"
+      value: "true"
+    - name: TARGET_MANAGED_SERVICES
+      value: "true"
     - name: DISTRIBUTION
-      value: "entpks"
+      value: "eks"
   image: sonobuoy/kube-bench:0.3.1
   name: plugin
   resources: {}
   volumeMounts:
   - mountPath: /tmp/results
     name: results
-  - name: var-vcap-jobs
-    mountPath: /var/vcap/jobs
+  - name: var-lib-etcd
+    mountPath: /var/lib/etcd
     readOnly: true
-  - name: var-vcap-data
-    mountPath: /var/vcap/data
+  - name: var-lib-kubelet
+    mountPath: /var/lib/kubelet
+    readOnly: true
+  - name: etc-systemd
+    mountPath: /etc/systemd
     readOnly: true
   - name: etc-kubernetes
     mountPath: /etc/kubernetes
@@ -71,6 +79,6 @@ spec:
   # /usr/bin is mounted to access kubectl / kubelet, used by kube-bench for auto-detecting the Kubernetes version.
   # It is mounted at the path /usr/local/mount-from-host/bin to avoid overwriting /usr/bin within the container.
   # You can omit this mount if you provide the version using the KUBERNETES_VERSION environment variable.
-  # - name: usr-bin
+  # - name: lib-systemd
   #   mountPath: /usr/local/mount-from-host/bin
   #   readOnly: true

--- a/cis-benchmarks/gke/kube-bench-plugin.yaml
+++ b/cis-benchmarks/gke/kube-bench-plugin.yaml
@@ -25,8 +25,8 @@ podSpec:
   #   hostPath:
   #     path: "/usr/bin"
   affinity:
-    nodeAffinity: 
-      requiredDuringSchedulingIgnoredDuringExecution: 
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
           - key: node-role.kubernetes.io/master
@@ -58,7 +58,7 @@ spec:
       value: "true"
     - name: DISTRIBUTION
       value: "gke"
-  image: sonobuoy/kube-bench:0.3.0
+  image: sonobuoy/kube-bench:0.3.1
   name: plugin
   resources: {}
   volumeMounts:
@@ -76,10 +76,9 @@ spec:
   - name: etc-kubernetes
     mountPath: /etc/kubernetes
     readOnly: true
-  # /usr/bin is mounted to access kubectl / kubelet, used by kube-bench for auto-detecting the Kubernetes version. 
+  # /usr/bin is mounted to access kubectl / kubelet, used by kube-bench for auto-detecting the Kubernetes version.
   # It is mounted at the path /usr/local/mount-from-host/bin to avoid overwriting /usr/bin within the container.
-  # You can omit this mount if you provide the version using the KUBERNETES_VERSION environment variable.           
+  # You can omit this mount if you provide the version using the KUBERNETES_VERSION environment variable.
   # - name: lib-systemd
   #   mountPath: /usr/local/mount-from-host/bin
   #   readOnly: true
-

--- a/cis-benchmarks/kube-bench-master-plugin.yaml
+++ b/cis-benchmarks/kube-bench-master-plugin.yaml
@@ -28,8 +28,8 @@ podSpec:
   #   hostPath:
   #     path: "/usr/bin"
   affinity:
-    nodeAffinity: 
-      requiredDuringSchedulingIgnoredDuringExecution: 
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
           - key: node-role.kubernetes.io/master
@@ -57,7 +57,7 @@ spec:
       value: "false"
     - name: TARGET_POLICIES
       value: "false"
-  image: sonobuoy/kube-bench:0.3.0
+  image: sonobuoy/kube-bench:0.3.1
   name: plugin
   resources: {}
   volumeMounts:

--- a/cis-benchmarks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/kube-bench-plugin.yaml
@@ -28,8 +28,8 @@ podSpec:
   #   hostPath:
   #     path: "/usr/bin"
   affinity:
-    nodeAffinity: 
-      requiredDuringSchedulingIgnoredDuringExecution: 
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
           - key: node-role.kubernetes.io/master
@@ -57,7 +57,7 @@ spec:
       value: "false"
     - name: TARGET_POLICIES
       value: "false"
-  image: sonobuoy/kube-bench:0.3.0
+  image: sonobuoy/kube-bench:0.3.1
   name: plugin
   resources: {}
   volumeMounts:
@@ -78,10 +78,9 @@ spec:
   - name: etc-kubernetes
     mountPath: /etc/kubernetes
     readOnly: true
-  # /usr/bin is mounted to access kubectl / kubelet, used by kube-bench for auto-detecting the Kubernetes version. 
+  # /usr/bin is mounted to access kubectl / kubelet, used by kube-bench for auto-detecting the Kubernetes version.
   # It is mounted at the path /usr/local/mount-from-host/bin to avoid overwriting /usr/bin within the container.
-  # You can omit this mount if you provide the version using the KUBERNETES_VERSION environment variable.           
+  # You can omit this mount if you provide the version using the KUBERNETES_VERSION environment variable.
   # - name: usr-bin
   #   mountPath: /usr/local/mount-from-host/bin
   #   readOnly: true
-

--- a/cis-benchmarks/run-kube-bench.sh
+++ b/cis-benchmarks/run-kube-bench.sh
@@ -112,7 +112,7 @@ get_targets() {
     # Other targets are only compatible with kube-bench for Kubernetes 1.15 and later.
     # If the Kubernetes version is known and is less than 1.15, don't add the targets if
     # they are requested.
-    # If the verison is not known (for example, using kube-bench verison autodetection), then
+    # If the version is not known (for example, using kube-bench version autodetection), then
     # these targets are always added if requested.
     if ! kubernetes_lt_1_15; then
         if [ "$TARGET_CONTROLPLANE" = true ]; then
@@ -130,7 +130,7 @@ get_targets() {
 
     # Some targets are distribution dependent and only work when running specific benchmark versions.
     case $DISTRIBUTION in
-        "gke"|"eks")
+        "gke")
             # The managedservices target is only compatible when running on GKE with the GKE specific benchmark,
             # or on EKS with the EKS specific benchmark
             # for Kubernetes 1.15 and later.

--- a/cis-benchmarks/run-kube-bench.sh
+++ b/cis-benchmarks/run-kube-bench.sh
@@ -31,8 +31,8 @@ get_config() {
         "entpks")
             config="cfg/entpks.yaml"
             ;;
-        "gke")
-            # Although we support GKE as a custom distribution, it uses the default configuration.
+        "gke"|"eks")
+            # Although we support GKE and EKS as custom distributions, they use the default configuration.
             ;;
         "")
             # If unset, use default config file.
@@ -75,6 +75,15 @@ get_version_or_benchmark_flag() {
                 vb_flag="--version $KUBERNETES_VERSION"
             else
                 vb_flag="--benchmark gke-1.0"
+            fi
+            ;;
+        "eks")
+            # The EKS specific benchmark is only suitable for Kubernetes 1.15 and later. If the provided
+            # version is less than this, fall back to specifying the version manually.
+            if kubernetes_lt_1_15 ; then
+                vb_flag="--version $KUBERNETES_VERSION"
+            else
+                vb_flag="--benchmark eks-1.0"
             fi
             ;;
         *)
@@ -121,12 +130,13 @@ get_targets() {
 
     # Some targets are distribution dependent and only work when running specific benchmark versions.
     case $DISTRIBUTION in
-        "gke")
-            # The managedservices target is only compatible when running on GKE with the GKE specific benchmark
+        "gke"|"eks")
+            # The managedservices target is only compatible when running on GKE with the GKE specific benchmark,
+            # or on EKS with the EKS specific benchmark
             # for Kubernetes 1.15 and later.
             # If the Kubernetes version is known and is less than 1.15, don't add the target if requested.
-            # If the verison is not known (for example, using kube-bench verison autodetection), then the
-            # the target is always added if requested.
+            # If the version is not known (for example, using kube-bench version autodetection), then the
+            # target is always added if requested.
             if [ "$TARGET_MANAGED_SERVICES" = true ] && ! kubernetes_lt_1_15; then
                 targets="${targets} managedservices"
             fi


### PR DESCRIPTION
Up until now we've been using the `kube-bench` sonobuoy plugin with the Kubernetes CIS Benchmark v1.5.0.

However AWS recently released their [EKS CIS Benchmark](https://aws.amazon.com/blogs/containers/introducing-cis-amazon-eks-benchmark/).

This PR therefore:

* Updates the Dockerfile to build from the latest version of `kube-bench`: `0.3.1`
* Updates all Sonobuoy manifests to use `sonobuoy/kube-bench:0.3.1`
* Updates the `run-kube-bench.sh` script to handle the new EKS distribution, and set the correct targets and version for kube-bench
* Add a `kube-bench-plugin.yaml` for EKS, with its README
* Fixes a few typos and removes a few trailing whitespaces. Let me know if you'd rather I remove that from the PR.
