### PR TITLE
Updating CSI-Benchmarks to lastest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.tar.gz
+.idea

--- a/cis-benchmarks/.ci/make.go
+++ b/cis-benchmarks/.ci/make.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"strings"
+
+	"github.com/vladimirvivien/echo"
+)
+
+var(
+	tasks = map[string]func(e *echo.Echo){
+		"all": all,
+		"docker_build": dockerBuild,
+		"docker_push": dockerPush,
+	}
+)
+
+// make.go used for CI builds
+// From project's root directory, run the followings for info
+// $ go run .ci/* --help
+func main() {
+	var version string
+	var targets string
+	flag.StringVar(&version, "version", "0.4.0", "kube-bench image version to build")
+	flag.StringVar(&targets, "targets", "all", "comma-separated list of build targets")
+	flag.Parse()
+
+	e := echo.New()
+	e.Conf.SetPanicOnErr(true)
+	e.SetVar("tag", version)
+	e.SetVar("docker_org", "sonobuoy")
+	e.SetVar("image_name", "kube-bench")
+	e.SetVar("repository", "${docker_org}/${image_name}:${tag}")
+	e.SetVar("repository_latest", "${docker_org}/${image_name}:latest")
+
+	for _, target := range strings.Split(targets,",") {
+		if task, ok := tasks[strings.TrimSpace(target)]; ok {
+			task(e)
+		}
+	}
+}
+
+func all(e *echo.Echo) {
+	dockerBuild(e)
+	dockerPush(e)
+}
+
+func dockerBuild(e *echo.Echo) {
+	log.Println(e.Eval("Building docker image: ${repository}, ${repository_latest}"))
+	e.Runout("docker build -t ${repository} -t ${repository_latest} -f Dockerfile .")
+}
+
+func dockerPush(e *echo.Echo) {
+	log.Println(e.Eval("Pushing docker image: ${repository}"))
+	e.Run("docker push ${repository}")
+
+	log.Println(e.Eval("Pushing docker image: ${repository_latest}"))
+	e.Run("docker push ${repository_latest}")
+}

--- a/cis-benchmarks/Dockerfile
+++ b/cis-benchmarks/Dockerfile
@@ -1,4 +1,4 @@
-FROM aquasec/kube-bench:0.3.1
+FROM aquasec/kube-bench:0.4.0
 
 COPY entpks/config.yaml cfg/entpks.yaml
 

--- a/cis-benchmarks/eks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/eks/kube-bench-plugin.yaml
@@ -58,7 +58,7 @@ spec:
       value: "false"
     - name: DISTRIBUTION
       value: "eks"
-  image: sonobuoy/kube-bench:0.3.1
+  image: sonobuoy/kube-bench:0.4.0
   name: plugin
   resources: {}
   volumeMounts:

--- a/cis-benchmarks/entpks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/entpks/kube-bench-plugin.yaml
@@ -53,7 +53,7 @@ spec:
       value: "false"
     - name: DISTRIBUTION
       value: "entpks"
-  image: sonobuoy/kube-bench:0.3.1
+  image: sonobuoy/kube-bench:0.4.0
   name: plugin
   resources: {}
   volumeMounts:

--- a/cis-benchmarks/gke/kube-bench-plugin.yaml
+++ b/cis-benchmarks/gke/kube-bench-plugin.yaml
@@ -58,7 +58,7 @@ spec:
       value: "true"
     - name: DISTRIBUTION
       value: "gke"
-  image: sonobuoy/kube-bench:0.3.1
+  image: sonobuoy/kube-bench:0.4.0
   name: plugin
   resources: {}
   volumeMounts:

--- a/cis-benchmarks/kube-bench-master-plugin.yaml
+++ b/cis-benchmarks/kube-bench-master-plugin.yaml
@@ -46,7 +46,7 @@ spec:
   - /run-kube-bench.sh; while true; do echo "Sleeping for 1h to avoid daemonset restart"; sleep 3600; done
   env:
     - name: KUBERNETES_VERSION
-      value: "1.17"
+      value: "1.19"
     - name: TARGET_MASTER
       value: "true"
     - name: TARGET_NODE
@@ -57,7 +57,7 @@ spec:
       value: "false"
     - name: TARGET_POLICIES
       value: "false"
-  image: sonobuoy/kube-bench:0.3.1
+  image: sonobuoy/kube-bench:0.4.0
   name: plugin
   resources: {}
   volumeMounts:

--- a/cis-benchmarks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/kube-bench-plugin.yaml
@@ -46,7 +46,7 @@ spec:
   - /run-kube-bench.sh; while true; do echo "Sleeping for 1h to avoid daemonset restart"; /bin/sleep 3600; done
   env:
     - name: KUBERNETES_VERSION
-      value: "1.17"
+      value: "1.19"
     - name: TARGET_MASTER
       value: "false"
     - name: TARGET_NODE
@@ -57,7 +57,7 @@ spec:
       value: "false"
     - name: TARGET_POLICIES
       value: "false"
-  image: sonobuoy/kube-bench:0.3.1
+  image: sonobuoy/kube-bench:0.4.0
   name: plugin
   resources: {}
   volumeMounts:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/vmware-tanzu/sonobuoy-plugins
+
+go 1.15
+
+require github.com/vladimirvivien/echo v0.0.1-alpha.6

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,1 @@
+github.com/vladimirvivien/echo v0.0.1-alpha.6/go.mod h1:64h/A7+5GmiBaeztyIr8BVf/07B7knV6OAP06jX+oyE=


### PR DESCRIPTION
This is to update the CSI-Benchmarks plugin to reflect changes in Kube-Bench release v0.4.0 - https://github.com/aquasecurity/kube-bench/releases/tag/v0.4.0