### PR TITLE
v0.0.2 bump golang + upgrade debian

### DIFF
--- a/cluster-inventory/Dockerfile
+++ b/cluster-inventory/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-buster as build
+FROM golang:1.15-buster as build
 
 COPY . /cluster-inventory
 WORKDIR /cluster-inventory

--- a/cluster-inventory/cluster-inventory.yaml
+++ b/cluster-inventory/cluster-inventory.yaml
@@ -29,7 +29,7 @@ spec:
     - /cluster-inventory run --sonobuoy-report /tmp/results/sonobuoy_results.yaml --json-report /tmp/results/json_results.json;
       tar czvf /tmp/results/results.tar.gz -C /tmp/results/ .;
       echo -n /tmp/results/results.tar.gz > /tmp/results/done
-  image: sonobuoy/cluster-inventory:v0.0.1
+  image: sonobuoy/cluster-inventory:v0.0.2
   name: plugin
   resources: {}
   volumeMounts:


### PR DESCRIPTION
Closes #39

Initially I wanted to use Distroless but it seems like the work isn't very trivial, considering the manual calls to `tar` in plugin manifest.