### PR TITLE
move annotations to namespace label check

### DIFF
--- a/reliability-scanner/Dockerfile
+++ b/reliability-scanner/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.7 AS build
+FROM golang:1.16.0 AS build
 
 WORKDIR /go/src/github.com/vmware-tanzu/sonobuoy-plugins/reliability-scanner
 

--- a/reliability-scanner/Makefile
+++ b/reliability-scanner/Makefile
@@ -1,6 +1,6 @@
 REGISTRY = "projects.registry.vmware.com/cre"
 IMAGE = "reliability-scanner"
-TAG = "v0.1.0"
+TAG = "v0.1.1"
 
 .SILENT: cycle
 clean:

--- a/reliability-scanner/README.md
+++ b/reliability-scanner/README.md
@@ -42,7 +42,7 @@ Checks currently available through the Reliability Scanner are as follows.
 | v1alpha1 | pod     | qos         | minimum_desired_qos_class | Defines the minimum desired QOS class for Pods running within the cluster. | String, ["BestEffort"/"Burstable"/"Guaranteed"] | "BestEffort"   |
 |          |         |             | include_detail            | Include detail of the current configured QOS class per Pod.                | Boolean, [true/false]                           | true           |
 | v1alpha1 | pod     | probes      | -                         | Checks if Pod Liveness/Readiness Probes are defined.                       | -                                               | -              |
-| v1alpha1 | service | annotations | key                       | Checks for a specific annotation key on a service kind.                    | String                                          | "incident-url" |
-|          |         |             | include_annotations       | Include currently configured annotations.                                  | Boolean, [true/false]                           | true           |                                                         
+| v1alpha1 | namespace | labels | key                       | Checks for a specific Namespace label.                    | String                                          | "owner" |
+|          |         |             | include_labels       | Include currently configured labels.                                  | Boolean, [true/false]                           | true           |                                                         
 
 Each check may be conditionally included and customized to suit the requirements of the target cluster. The default set of checks are defined in `./plugin/reliability-scanner-custom-values.lib.yml`.

--- a/reliability-scanner/cmd/reliability-scanner/scanner.go
+++ b/reliability-scanner/cmd/reliability-scanner/scanner.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+	"github.com/vmware-tanzu/sonobuoy-plugins/reliability-scanner/api/v1alpha1/namespace/labels"
 	"github.com/vmware-tanzu/sonobuoy-plugins/reliability-scanner/api/v1alpha1/pod/probes"
 	"github.com/vmware-tanzu/sonobuoy-plugins/reliability-scanner/api/v1alpha1/pod/qos"
-	"github.com/vmware-tanzu/sonobuoy-plugins/reliability-scanner/api/v1alpha1/service/annotations"
 	"github.com/vmware-tanzu/sonobuoy-plugins/reliability-scanner/internal"
 )
 
@@ -85,17 +85,17 @@ func scan() {
 				}).Error(err)
 			}
 			querier.AddtoRunner(runner)
-		case "v1alpha1/service/annotations":
-			includeAnnotations, err := strconv.ParseBool(checkCfg.Spec["include_annotations"])
+		case "v1alpha1/namespace/labels":
+			includeLabels, err := strconv.ParseBool(checkCfg.Spec["include_labels"])
 			if err != nil {
 				runner.Logger.WithFields(logrus.Fields{
 					"check_name": checkCfg.Spec["Name"],
 					"phase":      "add",
 				}).Error(err)
 			}
-			querier, err := annotations.NewQuerier(&annotations.QuerierSpec{
-				Key:                checkCfg.Spec["key"],
-				IncludeAnnotations: includeAnnotations,
+			querier, err := labels.NewQuerier(&labels.QuerierSpec{
+				Key:           checkCfg.Spec["key"],
+				IncludeLabels: includeLabels,
 			})
 			if err != nil {
 				runner.Logger.WithFields(logrus.Fields{

--- a/reliability-scanner/plugin/base.yaml
+++ b/reliability-scanner/plugin/base.yaml
@@ -10,7 +10,7 @@ spec:
       configMapKeyRef:
         name: reliability-scanner-cm
         key: reliability-scanner.yaml
-  image: projects.registry.vmware.com/cre/reliability-scanner:v0.1.0
+  image: projects.registry.vmware.com/cre/reliability-scanner:v0.1.1
   name: plugin
   resources: {}
   volumeMounts:

--- a/reliability-scanner/plugin/default-ytt.yaml
+++ b/reliability-scanner/plugin/default-ytt.yaml
@@ -91,7 +91,7 @@ data:
             configMapKeyRef:
               name: reliability-scanner-cm
               key: reliability-scanner.yaml
-      image: projects.registry.vmware.com/cre/reliability-scanner:v0.1.0
+      image: projects.registry.vmware.com/cre/reliability-scanner:v0.1.1
       imagePullPolicy: Always
       name: plugin
       resources: {}

--- a/reliability-scanner/plugin/reliability-scanner-custom-values.lib.yml
+++ b/reliability-scanner/plugin/reliability-scanner-custom-values.lib.yml
@@ -6,12 +6,12 @@ checks:
   spec:
     minimum_desired_qos_class: Guaranteed
     include_detail: true
-- name: "Service Owner Check"
-  description: Checks for a specific configurable annotation on all services in the cluster.
-  kind: v1alpha1/service/annotations
+- name: "Namespace Owner Check"
+  description: Checks Namespaces for an owner label.
+  kind: v1alpha1/namespace/labels
   spec:
-   key: incident-url
-   include_annotations: true
+   key: owner
+   include_labels: true
 - name: "Liveness and Readiness Probes"
   description: Checks for whether liveness probe and readiness probe are defined.
   kind: v1alpha1/pod/probes


### PR DESCRIPTION
Signed-off-by: Peter Grant <pegrant@vmware.com>

Moving this check to Namespace labels as this allows for better usage in tooling.