### PR TITLE
Update targets for EKS CIS Benchmarks

### DIFF
--- a/cis-benchmarks/eks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/eks/kube-bench-plugin.yaml
@@ -43,19 +43,19 @@ spec:
     - /run-kube-bench.sh; while true; do echo "Sleeping for 1h to avoid daemonset restart"; /bin/sleep 3600; done
   env:
     - name: KUBERNETES_VERSION
-      value: "1.15"
+      value: "1.19"
     - name: TARGET_MASTER
       value: "false"
     - name: TARGET_NODE
       value: "true"
     - name: TARGET_CONTROLPLANE
-      value: "false"
+      value: "true"
     - name: TARGET_ETCD
       value: "false"
     - name: TARGET_POLICIES
-      value: "false"
+      value: "true"
     - name: TARGET_MANAGED_SERVICES
-      value: "false"
+      value: "true"
     - name: DISTRIBUTION
       value: "eks"
   image: sonobuoy/kube-bench:0.4.0


### PR DESCRIPTION
This PR is a follow-up to: https://github.com/vmware-tanzu/sonobuoy-plugins/pull/27

At the time, the CIS Benchmark for EKS had just been released and added to kube-bench, but the only available targets was `TARGET_NODE`. 

Unfortunately I didn't get to it until now. But anyway, this PR:

- Enables CONTROLPLANE, POLICIES and MANAGED_SERVICES targets for checks following their support being added in kube-bench (https://github.com/aquasecurity/kube-bench/pull/648)
- Bumps Kubernetes version to [latest available on EKS](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)

Let me know if anything else is needed.

Cheers,

Matthieu
