### PR TITLE
Update version of kube-bench to latest v0.5.0

### DIFF
--- a/cis-benchmarks/.ci/make.go
+++ b/cis-benchmarks/.ci/make.go
@@ -22,7 +22,7 @@ var(
 func main() {
 	var version string
 	var targets string
-	flag.StringVar(&version, "version", "0.4.0", "kube-bench image version to build")
+	flag.StringVar(&version, "version", "0.5.0", "kube-bench image version to build")
 	flag.StringVar(&targets, "targets", "all", "comma-separated list of build targets")
 	flag.Parse()
 

--- a/cis-benchmarks/Dockerfile
+++ b/cis-benchmarks/Dockerfile
@@ -1,4 +1,4 @@
-FROM aquasec/kube-bench:0.4.0
+FROM aquasec/kube-bench:0.5.0
 
 COPY entpks/config.yaml cfg/entpks.yaml
 

--- a/cis-benchmarks/eks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/eks/kube-bench-plugin.yaml
@@ -58,7 +58,7 @@ spec:
       value: "false"
     - name: DISTRIBUTION
       value: "eks"
-  image: sonobuoy/kube-bench:0.4.0
+  image: sonobuoy/kube-bench:0.5.0
   name: plugin
   resources: {}
   volumeMounts:

--- a/cis-benchmarks/entpks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/entpks/kube-bench-plugin.yaml
@@ -53,7 +53,7 @@ spec:
       value: "false"
     - name: DISTRIBUTION
       value: "entpks"
-  image: sonobuoy/kube-bench:0.4.0
+  image: sonobuoy/kube-bench:0.5.0
   name: plugin
   resources: {}
   volumeMounts:

--- a/cis-benchmarks/gke/kube-bench-plugin.yaml
+++ b/cis-benchmarks/gke/kube-bench-plugin.yaml
@@ -58,7 +58,7 @@ spec:
       value: "true"
     - name: DISTRIBUTION
       value: "gke"
-  image: sonobuoy/kube-bench:0.4.0
+  image: sonobuoy/kube-bench:0.5.0
   name: plugin
   resources: {}
   volumeMounts:

--- a/cis-benchmarks/kube-bench-master-plugin.yaml
+++ b/cis-benchmarks/kube-bench-master-plugin.yaml
@@ -57,7 +57,7 @@ spec:
       value: "false"
     - name: TARGET_POLICIES
       value: "false"
-  image: sonobuoy/kube-bench:0.4.0
+  image: sonobuoy/kube-bench:0.5.0
   name: plugin
   resources: {}
   volumeMounts:

--- a/cis-benchmarks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/kube-bench-plugin.yaml
@@ -57,7 +57,7 @@ spec:
       value: "false"
     - name: TARGET_POLICIES
       value: "false"
-  image: sonobuoy/kube-bench:0.4.0
+  image: sonobuoy/kube-bench:0.5.0
   name: plugin
   resources: {}
   volumeMounts:


### PR DESCRIPTION
This PR bumps the version of `kube-bench` to the latest `0.5.0`.

The version is bumped across all manifests, Dockerfile and `.ci/make.go`

Let me know if anything else is missing,

Cheers,

Matthieu
