### PR TITLE
Add e2e and systemd-logs default plugins

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,38 @@
+# e2e Plugin (Kubernetes End-To-End Tests)
+
+### Introduction
+
+The e2e plugin is the primary use case that [sonobuoy][sonobuoy] is known for. It runs the Kubernetes end-to-end tests on your targeted cluster.
+
+Typically, there is no reason to target this YAML specifically as the sonobuoy CLI houses and generates it for you so that you can run this plugin simply by running:
+
+```
+sonobuoy run
+```
+
+And you can generate this plugin (with minor modifications) by running:
+
+```
+sonobuoy gen plugin e2e
+```
+
+### Windows Tests
+
+Running e2e tests on Windows requires numerous modifications to this plugin and so it has its own so that running it is more simple.
+
+See the [Windows plugin][windows] for more details and our [blog][windowsBlog] for a more thorough discussion.
+
+### The Tests
+
+The tests themselves are written by "upstream" Kubernetes 
+and live in the [Kubernetes repo][kubernetes].
+
+### Other Resources
+
+See [sonobuoy.io][sonobuoySite] for additional documentation, blogs, and resources.
+
+[sonobuoy]: https://github.com/vmware-tanzu/sonobuoy
+[sonobuoySite]: https://sonobuoy.io/
+[kubernetes]: https://github.com/kubernetes/kubernetes
+[windows]: windows-e2e
+[windowsBlog]: https://sonobuoy.io/windows-e2e-tests-with-sonobuoy/

--- a/e2e/e2e.yaml
+++ b/e2e/e2e.yaml
@@ -1,0 +1,39 @@
+podSpec:
+  containers: []
+  nodeSelector:
+    kubernetes.io/os: linux
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+    operator: Exists
+  - key: CriticalAddonsOnly
+    operator: Exists
+  - key: kubernetes.io/e2e-evict-taint-key
+    operator: Exists
+sonobuoy-config:
+  driver: Job
+  plugin-name: e2e
+  result-format: junit
+spec:
+  command:
+  - /run_e2e.sh
+  env:
+  - name: E2E_EXTRA_ARGS
+    value: --progress-report-url=http://localhost:8099/progress
+  - name: E2E_FOCUS
+    value: \[Conformance\]
+  - name: E2E_PARALLEL
+    value: "false"
+  - name: E2E_SKIP
+    value: \[Disruptive\]|NoExecuteTaintManager
+  - name: E2E_USE_GO_RUNNER
+    value: "true"
+  image: k8s.gcr.io/conformance:$SONOBUOY_K8S_VERSION
+  imagePullPolicy: IfNotPresent
+  name: e2e
+  resources: {}
+  volumeMounts:
+  - mountPath: /tmp/results
+    name: results

--- a/systemd-logs/README.md
+++ b/systemd-logs/README.md
@@ -3,3 +3,9 @@
 This is a simple standalone container that gathers log information from systemd, by chrooting into the node's filesystem and running `journalctl`.
 
 This container is used by [Sonobuoy](https://github.com/vmware-tanzu/sonobuoy) for gathering host logs in a Kubernetes cluster.
+
+You typically do not need to target this plugin manually since it is currently included in the sonobuoy CLI and runs automatically when you run:
+
+```
+sonobuoy run
+```

--- a/systemd-logs/systemd-logs.yaml
+++ b/systemd-logs/systemd-logs.yaml
@@ -1,0 +1,30 @@
+sonobuoy-config:
+  driver: DaemonSet
+  plugin-name: systemd-logs
+  result-format: raw
+spec:
+  command:
+  - /bin/sh
+  - -c
+  - /get_systemd_logs.sh; while true; do echo "Plugin is complete. Sleeping indefinitely
+    to avoid container exit and automatic restarts from Kubernetes"; sleep 3600; done
+  env:
+  - name: CHROOT_DIR
+    value: /node
+  - name: NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  - name: RESULTS_DIR
+    value: /tmp/results
+  image: sonobuoy/systemd-logs:v0.3
+  imagePullPolicy: IfNotPresent
+  name: systemd-logs
+  resources: {}
+  securityContext:
+    privileged: true
+  volumeMounts:
+  - mountPath: /tmp/results
+    name: results
+  - mountPath: /node
+    name: root


### PR DESCRIPTION
As part of extracting the default plugins from the core of
Sonobuoy, it seemed like a good place to start would be placing
the YAML here. We can move it around as necessary after this.

Signed-off-by: John Schnake <jschnake@vmware.com>