### PR TITLE
Add s390x architecture support to systemd-logs image

### DIFF
--- a/systemd-logs/Dockerfile
+++ b/systemd-logs/Dockerfile
@@ -17,7 +17,7 @@
 ARG IMAGEARCH
 FROM alpine:3.9.2 as qemu
 RUN apk add --no-cache curl
-ARG QEMUVERSION=2.9.1
+ARG QEMUVERSION=6.1.0-6
 ARG QEMUARCH
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]

--- a/systemd-logs/Makefile
+++ b/systemd-logs/Makefile
@@ -24,8 +24,8 @@ DIR := ${CURDIR}
 VERSION ?= v0.3
 
 ARCH    ?= amd64
-LINUX_ARCHS = amd64 arm64 ppc64le
-PLATFORMS = linux/amd64,linux/arm64,linux/ppc64le
+LINUX_ARCHS = amd64 arm64 ppc64le s390x
+PLATFORMS = linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
 
 IMAGEARCH ?=
 QEMUARCH  ?=
@@ -48,6 +48,9 @@ QEMUARCH  = aarch64
 else ifeq ($(ARCH),ppc64le)
 IMAGEARCH = ppc64le/
 QEMUARCH  = ppc64le
+else ifeq ($(ARCH),s390x)
+IMAGEARCH = s390x/
+QEMUARCH  = s390x
 else
 $(error unknown arch "$(ARCH)")
 endif


### PR DESCRIPTION
qemu-user-static version was also bumped to the latest one(v6.1.0-6).
This is part of work to enable [s390x sonobuoy builds](https://github.com/vmware-tanzu/sonobuoy/issues/1454#issuecomment-937893572).

Signed-off-by: Yulia Gaponenko <yulia.gaponenko1@de.ibm.com>