### PR TITLE
systemd-logs: Bump release and notes

### DIFF
--- a/systemd-logs/Makefile
+++ b/systemd-logs/Makefile
@@ -21,7 +21,7 @@ REGISTRY ?= sonobuoy
 IMAGE = $(REGISTRY)/$(TARGET)
 DOCKER ?= docker
 DIR := ${CURDIR}
-VERSION ?= v0.3
+VERSION ?= v0.4
 
 ARCH    ?= amd64
 LINUX_ARCHS = amd64 arm64 ppc64le s390x

--- a/systemd-logs/README.md
+++ b/systemd-logs/README.md
@@ -9,3 +9,17 @@ You typically do not need to target this plugin manually since it is currently i
 ```
 sonobuoy run
 ```
+
+## Releases
+
+To build/push for release run:
+
+```bash
+make push
+```
+
+If you are on a Mac when pushing you'll need to modify the Makefile
+to download the darwin version of the manifest-tool and also
+provide --username and --password in the `push_manifest` target. Because
+of the way Mac handles the Docker credentials, the manifest-tool doesn't
+properly access them otherwise.

--- a/systemd-logs/systemd-logs.yaml
+++ b/systemd-logs/systemd-logs.yaml
@@ -17,7 +17,7 @@ spec:
         fieldPath: spec.nodeName
   - name: RESULTS_DIR
     value: /tmp/results
-  image: sonobuoy/systemd-logs:v0.3
+  image: sonobuoy/systemd-logs:v0.4
   imagePullPolicy: IfNotPresent
   name: systemd-logs
   resources: {}


### PR DESCRIPTION
Previous commits added s390x and ppc64le so I
pushed a new version for systemd-logs.

Signed-off-by: John Schnake <jschnake@vmware.com>