### PR TITLE
cis-benchmark: support skipping kube-bench tests

### DIFF
--- a/cis-benchmarks/README.md
+++ b/cis-benchmarks/README.md
@@ -60,6 +60,8 @@ Each of targets can be enabled or disabled by setting the value for the appropri
 * `TARGET_POLICIES`
   Setting this to "true" enables the checks for Kubernetes policies. For CIS 1.5, this is Section 2. This target cannot be enabled for earlier versions of the benchmark.
   This is disabled by default in both plugins.
+* `SKIP`
+   Will be passed to the `--skip` flag of kube-bench: List of comma separated values of checks to be skipped.
 
 The following environment variables are distribution specific.
 They should not be enabled unless you are running against a distribution where they are valid and compatible.

--- a/cis-benchmarks/run-kube-bench.sh
+++ b/cis-benchmarks/run-kube-bench.sh
@@ -148,13 +148,25 @@ get_targets() {
     echo $targets
 }
 
+# Returns the skip flag if SKIP is not empty
+get_skip_flag() {
+    local skip_flag
+
+    if [ ! -z "$SKIP" ]; then
+        skip_flag="--skip $SKIP"
+    fi
+
+    echo $skip_flag
+}
+
 run_kube_bench() {
     local config="$(get_config)"
     local vb_flag="$(get_version_or_benchmark_flag)"
     local targets="$(get_targets)"
+    local skip_flag="$(get_skip_flag)"
 
     for target in $targets; do
-        kube-bench --config $config run $vb_flag --targets $target --outputfile ${SONOBUOY_RESULTS_DIR}/$target.xml --junit
+        kube-bench --config $config run $vb_flag --targets $target $skip_flag --outputfile ${SONOBUOY_RESULTS_DIR}/$target.xml --junit
     done
 
     tar czf ${SONOBUOY_RESULTS_DIR}/results.tar.gz ${SONOBUOY_RESULTS_DIR}/*.xml


### PR DESCRIPTION
kube-bench 0.5 added the possibility to skip single tests which may not apply to a specific setup. This pull request exposes this option as a sonobuoy plugin option.