### PR TITLE
Fix cluster-inventory SONOBUOY_RESULTS_DIR reference

### DIFF
--- a/cluster-inventory/cluster-inventory.yaml
+++ b/cluster-inventory/cluster-inventory.yaml
@@ -26,15 +26,13 @@ spec:
     - /bin/bash
   args:
     - -c
-    - /cluster-inventory run --sonobuoy-report /tmp/results/sonobuoy_results.yaml --json-report /tmp/results/json_results.json;
-      tar czvf /tmp/results/results.tar.gz -C /tmp/results/ .;
-      echo -n /tmp/results/results.tar.gz > /tmp/results/done
+    - /cluster-inventory run --sonobuoy-report $(SONOBUOY_RESULTS_DIR)/sonobuoy_results.yaml --json-report $(SONOBUOY_RESULTS_DIR)/json_results.json;
+      tar czvf $(SONOBUOY_RESULTS_DIR)/results.tar.gz -C $(SONOBUOY_RESULTS_DIR)/ .;
+      echo -n $(SONOBUOY_RESULTS_DIR)/results.tar.gz > $(SONOBUOY_RESULTS_DIR)/done
   image: sonobuoy/cluster-inventory:v0.0.2
   name: plugin
   resources: {}
   volumeMounts:
-  - mountPath: /tmp/results
-    name: results
   - mountPath: /etc/cni/net.d
     name: etc-cni-netd
   - mountPath: /opt/cni/bin


### PR DESCRIPTION
- Used outdated, hardcoded value
- Sonobuoy was overwriting the results_dir specified by plugin
because it did not  match the value specified in the config file
- Using the env var will be more robust than hardcoding the new value

Fixes #79 

Signed-off-by: John Schnake <jschnake@vmware.com>