### PR TITLE
cis-benchmarks: Use env var instead of hardcoded path

### DIFF
--- a/cis-benchmarks/kube-bench-master-plugin.yaml
+++ b/cis-benchmarks/kube-bench-master-plugin.yaml
@@ -61,7 +61,7 @@ spec:
   name: plugin
   resources: {}
   volumeMounts:
-  - mountPath: /tmp/results
+  - mountPath: /tmp/sonobuoy/results
     name: results
   - name: var-lib-etcd
     mountPath: /var/lib/etcd

--- a/cis-benchmarks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/kube-bench-plugin.yaml
@@ -61,7 +61,7 @@ spec:
   name: plugin
   resources: {}
   volumeMounts:
-  - mountPath: /tmp/results
+  - mountPath: /tmp/sonobuoy/results
     name: results
   - name: var-lib-etcd
     mountPath: /var/lib/etcd

--- a/cis-benchmarks/run-kube-bench.sh
+++ b/cis-benchmarks/run-kube-bench.sh
@@ -154,11 +154,11 @@ run_kube_bench() {
     local targets="$(get_targets)"
 
     for target in $targets; do
-        kube-bench --config $config run $vb_flag --targets $target --outputfile /tmp/results/$target.xml --junit
+        kube-bench --config $config run $vb_flag --targets $target --outputfile ${SONOBUOY_RESULTS_DIR}/$target.xml --junit
     done
 
-    tar czf /tmp/results/results.tar.gz /tmp/results/*.xml
-    echo -n /tmp/results/results.tar.gz > /tmp/results/done
+    tar czf ${SONOBUOY_RESULTS_DIR}/results.tar.gz ${SONOBUOY_RESULTS_DIR}/*.xml
+    echo -n ${SONOBUOY_RESULTS_DIR}/results.tar.gz > ${SONOBUOY_RESULTS_DIR}/done
 }
 
 run_kube_bench


### PR DESCRIPTION
Similar to other plugins, the env var for results path should
be used instead of the hardcoded path in case the user is specifying
another directory. Sonobuoy ensures the plugin uses the intended
mount regardless of what is hardcoded into the plugin definition.

Signed-off-by: John Schnake <jschnake@vmware.com>

Fixes #91