### PR TITLE
Plugin-Helper counts fix and Donefile writing

### DIFF
--- a/plugin-helper/progress.go
+++ b/plugin-helper/progress.go
@@ -43,16 +43,19 @@ func(r *ProgressReporter) StartTest(name string){
 // StopTest will increase the tests counts and send an update message accordingly.
 func(r *ProgressReporter) StopTest(name string,failed,skipped bool, err error){
 	msg:=""
-	r.completed+=1
 	if failed{
+		// Completed count not incremented when failing tests added.
 		r.failures=append(r.failures,name)
 		msg = fmt.Sprintf("Test failed: %v",name)
 	}else if skipped{
+		r.completed+=1
 		msg = fmt.Sprintf("Test skipped: %v",name)
 	}else if err !=nil{
+		r.completed+=1
 		r.errors=append(r.errors,name)
 		msg = fmt.Sprintf("Test errored: %v %v",name,err.Error())
 	}else{
+		r.completed+=1
 		msg = fmt.Sprintf("Test completed: %v",name)
 	}
 	r.SendMessage(msg)

--- a/plugin-helper/resultswriter.go
+++ b/plugin-helper/resultswriter.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	defaultOutputFileName = "manual_results.yaml"
+	defaultOutputFileName = "sonobuoy_results.yaml"
 )
 
 type SonobuoyResultsWriter struct {
@@ -57,7 +57,7 @@ func (w *SonobuoyResultsWriter) AddTest(
 	w.Data.Items = append(w.Data.Items, i)
 }
 
-func (w *SonobuoyResultsWriter) Done() error {
+func (w *SonobuoyResultsWriter) Done(writeDoneFile bool) error {
 	w.Data.Status = sono.AggregateStatus(w.Data.Items...)
 
 	outfile, err := os.Create(filepath.Join(w.ResultsDir, w.OutputFile))
@@ -68,6 +68,11 @@ func (w *SonobuoyResultsWriter) Done() error {
 
 	enc := yaml.NewEncoder(outfile)
 	defer enc.Close()
-	err = enc.Encode(w.Data)
-	return errors.Wrap(err, "error writing to results file")
+	if err := enc.Encode(w.Data); err!=nil{
+		return errors.Wrap(err, "error writing to results file")
+	}
+	if writeDoneFile{
+		return Done()
+	}
+	return nil
 }


### PR DESCRIPTION
- When a test fails the completed count is not incremented. Failed+completed=total at the end
- When reporting you're done with tests, you shouldn't have to make a separate call to write
the done file.

Signed-off-by: John Schnake <jschnake@vmware.com>