### PR TITLE
Plugin-helper: ResultsWriter shouldn't err if no resultsDir set

### DIFF
--- a/plugin-helper/helper.go
+++ b/plugin-helper/helper.go
@@ -9,36 +9,41 @@ import (
 	"github.com/vmware-tanzu/sonobuoy/pkg/tarball"
 )
 
-const(
-	SonobuoyResultsDirKey="SONOBUOY_RESULTS_DIR"
-	DoneFileName = "done"
-	DefaultTarballName = "results.tar.gz"
+const (
+	SonobuoyResultsDirKey = "SONOBUOY_RESULTS_DIR"
+	DoneFileName          = "done"
+	DefaultTarballName    = "results.tar.gz"
 )
 
 // Done will tar up the results directory, write the done file which instructs Sonobuoy to
 // submit results to the aggregator.
-func Done() error{
+func Done() error {
 	dir := GetResultsDir()
+	if len(dir) == 0 {
+		logrus.Warnf("No %v set, no results directory will be archived and no 'done file' will be written.", SonobuoyResultsDirKey)
+		return nil
+	}
+
 	outputFile := filepath.Join(dir, DefaultTarballName)
-	logrus.Tracef("Tarring up directory: %v",dir)
-	if err := tarball.DirToTarball(dir, outputFile,true ); err!=nil{
-		return fmt.Errorf("failed to tar up entire results directory: %w",err)
+	logrus.Tracef("Tarring up directory: %v", dir)
+	if err := tarball.DirToTarball(dir, outputFile, true); err != nil {
+		return fmt.Errorf("failed to tar up entire results directory: %w", err)
 	}
 	logrus.Trace("Writing done file...")
-	if err:= WriteDone(outputFile); err !=nil{
+	if err := WriteDone(outputFile); err != nil {
 		return err
 	}
 	logrus.Trace("Done file written without error.")
 	return nil
 }
 
-func GetResultsDir() string{
+func GetResultsDir() string {
 	return os.Getenv(SonobuoyResultsDirKey)
 }
 
-func WriteDone(resultsPath string) error{
-	if err:=os.WriteFile(filepath.Join(GetResultsDir(), DoneFileName), []byte(resultsPath), 0666); err !=nil{
-		return fmt.Errorf("failed write done file: %w",err)
+func WriteDone(resultsPath string) error {
+	if err := os.WriteFile(filepath.Join(GetResultsDir(), DoneFileName), []byte(resultsPath), 0666); err != nil {
+		return fmt.Errorf("failed write done file: %w", err)
 	}
 	return nil
 }

--- a/plugin-helper/progress.go
+++ b/plugin-helper/progress.go
@@ -12,91 +12,91 @@ import (
 	"github.com/vmware-tanzu/sonobuoy/pkg/plugin"
 )
 
-const(
-	SonobuoyProgressPortEnvKey="SONOBUOY_PROGRESS_PORT"
+const (
+	SonobuoyProgressPortEnvKey = "SONOBUOY_PROGRESS_PORT"
 )
 
-type ProgressReporter struct{
+type ProgressReporter struct {
 	total, completed int64
 	failures, errors []string
-	c *http.Client
-	port string
+	c                *http.Client
+	port             string
 }
 
 // NewProgressReporter will initialize a progress reporter which expects the given number of tests. If
 // it fails to generate a reporter, it will return the empty reporter which executes noops.
-func NewProgressReporter(total int64) ProgressReporter{
+func NewProgressReporter(total int64) ProgressReporter {
 	progressPort := os.Getenv(SonobuoyProgressPortEnvKey)
-	if progressPort ==""{
-		logrus.Tracef("No %v env var set; no progress updates will be sent.",SonobuoyProgressPortEnvKey)
+	if progressPort == "" {
+		logrus.Tracef("No %v env var set; no progress updates will be sent.", SonobuoyProgressPortEnvKey)
 		return ProgressReporter{}
 	}
-	logrus.Tracef("ProgressReporter created with %v total tests expected. Will send requests to localhost:%v",total,progressPort)
-	return ProgressReporter{total:total,c:&http.Client{Timeout: 30*time.Second}, port:progressPort}
+	logrus.Tracef("ProgressReporter created with %v total tests expected. Will send requests to localhost:%v", total, progressPort)
+	return ProgressReporter{total: total, c: &http.Client{Timeout: 30 * time.Second}, port: progressPort}
 }
 
 // StartTest will send a progress update indicating the start of the given test.
-func(r *ProgressReporter) StartTest(name string){
+func (r *ProgressReporter) StartTest(name string) {
 	r.SendMessage(fmt.Sprintf("Test started: %v", name))
 }
 
 // StopTest will increase the tests counts and send an update message accordingly.
-func(r *ProgressReporter) StopTest(name string,failed,skipped bool, err error){
-	msg:=""
-	if failed{
+func (r *ProgressReporter) StopTest(name string, failed, skipped bool, err error) {
+	msg := ""
+	if failed {
 		// Completed count not incremented when failing tests added.
-		r.failures=append(r.failures,name)
-		msg = fmt.Sprintf("Test failed: %v",name)
-	}else if skipped{
-		r.completed+=1
-		msg = fmt.Sprintf("Test skipped: %v",name)
-	}else if err !=nil{
-		r.completed+=1
-		r.errors=append(r.errors,name)
-		msg = fmt.Sprintf("Test errored: %v %v",name,err.Error())
-	}else{
-		r.completed+=1
-		msg = fmt.Sprintf("Test completed: %v",name)
+		r.failures = append(r.failures, name)
+		msg = fmt.Sprintf("Test failed: %v", name)
+	} else if skipped {
+		r.completed += 1
+		msg = fmt.Sprintf("Test skipped: %v", name)
+	} else if err != nil {
+		r.completed += 1
+		r.errors = append(r.errors, name)
+		msg = fmt.Sprintf("Test errored: %v %v", name, err.Error())
+	} else {
+		r.completed += 1
+		msg = fmt.Sprintf("Test completed: %v", name)
 	}
 	r.SendMessage(msg)
 }
 
 // SendMessage should be used for sending arbitrary messages. This method waits for a response,
 // use SendMessageAsync for an asynchronous call.
-func(r *ProgressReporter) SendMessage(msg string)error{
-	if r.c==nil {
+func (r *ProgressReporter) SendMessage(msg string) error {
+	if r.c == nil {
 		logrus.Warnln("Progress update attempted but no client available.")
 		return nil
 	}
 
 	update := plugin.ProgressUpdate{
-		Timestamp:  time.Time{},
-		Message:    msg,
-		Total:      r.total,
-		Completed:  r.completed,
-		Errors:     r.errors,
-		Failures:   r.failures,
+		Timestamp: time.Time{},
+		Message:   msg,
+		Total:     r.total,
+		Completed: r.completed,
+		Errors:    r.errors,
+		Failures:  r.failures,
 	}
-	b,err := json.Marshal(update)
-	if err !=nil{
-		return fmt.Errorf("failed to marshal progress update: %w",err)
+	b, err := json.Marshal(update)
+	if err != nil {
+		return fmt.Errorf("failed to marshal progress update: %w", err)
 	}
 
-	resp,err := r.c.Post(fmt.Sprintf("http://localhost:%v/progress",r.port),"",bytes.NewReader(b))
-	if err !=nil{
-		return fmt.Errorf("failed to POST progress update: %w",err)
+	resp, err := r.c.Post(fmt.Sprintf("http://localhost:%v/progress", r.port), "", bytes.NewReader(b))
+	if err != nil {
+		return fmt.Errorf("failed to POST progress update: %w", err)
 	}
-	if resp.StatusCode != http.StatusOK{
-		return fmt.Errorf("unexpected HTTP Status from progress update: %v (%v)", resp.Status,resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected HTTP Status from progress update: %v (%v)", resp.Status, resp.StatusCode)
 	}
 	return nil
 }
 
-func (r *ProgressReporter) SendMessageAsync(msg string)  {
-	go func(){
+func (r *ProgressReporter) SendMessageAsync(msg string) {
+	go func() {
 		err := r.SendMessage(msg)
-		if err !=nil{
-			logrus.Errorf("Failed to send progress update: %w",err)
+		if err != nil {
+			logrus.Errorf("Failed to send progress update: %v", err)
 		}
 	}()
 }

--- a/plugin-helper/resultswriter_test.go
+++ b/plugin-helper/resultswriter_test.go
@@ -1,0 +1,18 @@
+package plugin_helper
+
+import (
+	sono "github.com/vmware-tanzu/sonobuoy/pkg/client/results"
+)
+
+func ExampleWriterDoneToStdout() {
+	// Note: The spacing looks weird in the output here just because of tabbing and yaml encoding.
+	// The real point of the test is to ensure that a writer without a resultsDir will write to stdout.
+	w := &SonobuoyResultsWriter{}
+	w.Data = sono.Item{Name: "suite", Status: "shouldAggregateToPassed", Items: []sono.Item{{Name: "t1", Status: "passed"}}}
+	w.Done(false)
+	//Output: name: suite
+	//status: passed
+	//items:
+	//- name: t1
+	//   status: passed
+}


### PR DESCRIPTION
In non-cluster environments (e.g. running code that would be containerized
for a plugin, but running it locally) the SONOBUOY_RESULTS_DIR won't
be set and so we shouldn't cause users to write special if/then logic
to turn off that functionality.

We should simply detect this state and write to stdout and/or log
when appropriate.

Signed-off-by: John Schnake <jschnake@vmware.com>