### PR TITLE
Adding node selector so it doesn't schedule on a Windows node.

### DIFF
--- a/cluster-inventory/cluster-inventory.yaml
+++ b/cluster-inventory/cluster-inventory.yaml
@@ -1,5 +1,7 @@
 podSpec:
   containers: []
+  nodeSelector:
+    kubernetes.io/os: linux
   restartPolicy: Never
   serviceAccountName: sonobuoy-serviceaccount
   tolerations:


### PR DESCRIPTION
When running the current plugin, it can try to schedule on a Windows node which will cause it to error. Setting the default to Linux will prevent this issue.

* https://github.com/vmware-tanzu/sonobuoy-plugins/issues/101

Signed-off-by: Jamie Phillips <jamie.phillips@suse.com>