### PR TITLE
Fix cmd-runner plugin

### DIFF
--- a/examples/cmd-runner/Dockerfile
+++ b/examples/cmd-runner/Dockerfile
@@ -16,4 +16,6 @@ RUN apt-get update && \
 
 COPY ./run.sh ./run.sh 
 
+RUN chmod +x ./run.sh
+
 ENTRYPOINT ["./run.sh"]

--- a/examples/cmd-runner/run.sh
+++ b/examples/cmd-runner/run.sh
@@ -7,8 +7,10 @@ set -x
 
 results_dir="${RESULTS_DIR:-/tmp/results}"
 
+mkdir -p ${results_dir}
+
 # saveResults prepares the results for handoff to the Sonobuoy worker.
-# See: https://github.com/vmware-tanzu/sonobuoy/blob/master/docs/plugins.md
+# See: https://github.com/vmware-tanzu/sonobuoy/blob/main/site/content/docs/main/plugins.md
 saveResults() {
     cd ${results_dir}
 


### PR DESCRIPTION
In testing the `cmd-runner` plugin, I found that by default it fails to build, as can be evidenced by running `docker build` and `docker run`. The issues seemed to stem from the fact that the `run.sh` script was not marked as an executable, and that the existence of the `results_dir` is not verified. This change fixes these issues, and updates a stale doc link. After making these changes, I was successfully able to build and run the image, as well as run it successfully in a `sonobuoy run`.