### PR TITLE
ensure ResultsDir exists

### DIFF
--- a/plugin-helper/resultswriter.go
+++ b/plugin-helper/resultswriter.go
@@ -1,6 +1,7 @@
 package plugin_helper
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -65,6 +66,10 @@ func (w *SonobuoyResultsWriter) Done(writeDoneFile bool) error {
 
 	out := os.Stdout
 	if len(w.ResultsDir) > 0 {
+		# Ensure ResultsDir already exists
+		if err := MkdirAll(w.ResultsDir, fs.ModeDir|fs.ModePerm); err != nil {
+			return errors.Wrap(err, "error creating results directory")
+		}
 		outfile, err := os.Create(filepath.Join(w.ResultsDir, w.OutputFile))
 		if err != nil {
 			return errors.Wrap(err, "error creating results file")

--- a/plugin-helper/resultswriter.go
+++ b/plugin-helper/resultswriter.go
@@ -66,8 +66,8 @@ func (w *SonobuoyResultsWriter) Done(writeDoneFile bool) error {
 
 	out := os.Stdout
 	if len(w.ResultsDir) > 0 {
-		# Ensure ResultsDir already exists
-		if err := MkdirAll(w.ResultsDir, fs.ModeDir|fs.ModePerm); err != nil {
+		// Ensure ResultsDir already exists
+		if err := os.MkdirAll(w.ResultsDir, fs.ModeDir|fs.ModePerm); err != nil {
 			return errors.Wrap(err, "error creating results directory")
 		}
 		outfile, err := os.Create(filepath.Join(w.ResultsDir, w.OutputFile))


### PR DESCRIPTION
When testing some changes for #107 I ran into an issue where the ResultsFile failed to be written because ResultsDir didn't already exist. 

```
2022/03/10 22:54:54 error creating results file: open /tmp/sonobuoy/results/sonoshell.yaml: no such file or directory
```

This patch fixes `Done` to ensure that the directory exists before trying to write a file there.

Signed-off-by: Lilith McMullen <lmcmullen@twitter.com>