### PR TITLE
requirements-check v0.0.1 and image/plugin tweaks

### DIFF
--- a/requirements-check/Dockerfile
+++ b/requirements-check/Dockerfile
@@ -6,18 +6,23 @@ FROM golang:1.17-buster as build
 RUN wget https://storage.googleapis.com/kubernetes-release/release/v1.21.3/bin/linux/amd64/kubectl -O /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl
 
-COPY ./pkg /requirements-check/pkg
+# Copy go.[mod|sum] first and download deps to utilize docker cache.
 COPY go.sum /requirements-check/go.sum
 COPY go.mod /requirements-check/go.mod
 WORKDIR /requirements-check
+RUN go mod download
+
+# Copy the rest of the project files.
+COPY ./pkg /requirements-check/pkg
 
 RUN go build -o binary ./pkg
 
 FROM debian:buster-slim
-
-COPY --from=build /requirements-check/binary /requirements-check
-COPY --from=build /usr/bin/kubectl /usr/bin/kubectl
 # Add jq; moving just the binary caused issues with some dynamic libraries.
 RUN apt-get update && \
     apt-get install -y jq
+
+COPY --from=build /requirements-check/binary /requirements-check
+COPY --from=build /usr/bin/kubectl /usr/bin/kubectl
+
 CMD ["bash", "-c", "/requirements-check"]

--- a/requirements-check/build.sh
+++ b/requirements-check/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-docker build . -t schnake/requirementscheck:v0
-docker push schnake/requirementscheck:v0
+docker build . -t sonobuoy/requirementscheck:v0.0.1
+docker push sonobuoy/requirementscheck:v0.0.1

--- a/requirements-check/plugin.yaml
+++ b/requirements-check/plugin.yaml
@@ -49,15 +49,11 @@ config-map:
     ]
 sonobuoy-config:
   driver: Job
-  plugin-name: clusterquery
+  plugin-name: requirements-check
   result-format: manual
+  skip-cleanup: true
 spec:
   command:
-  - ./cluster-query
-  image: schnake/requirementscheck:v0
+  - /requirements-check
+  image: sonobuoy/requirementscheck:v0.0.1
   name: plugin
-  resources: {}
-  volumeMounts:
-  - mountPath: /tmp/results
-    name: results
-


### PR DESCRIPTION
This was originally released with some remnants of a rough POC. Changes
in this include:

 - utilize docker cache for go mod download
 - reference sonobuoy registry rather than my own
 - use version v0.0.1 instead of v0
 - fix naming in the plugin.yaml file

Fixes #112
Fixes #113

Signed-off-by: John Schnake <jschnake@vmware.com>