### PR TITLE
Bump kubebench to v0.6.4

### DIFF
--- a/cis-benchmarks/Dockerfile
+++ b/cis-benchmarks/Dockerfile
@@ -1,4 +1,4 @@
-FROM aquasec/kube-bench:0.6.3
+FROM aquasec/kube-bench:v0.6.4
 
 COPY entpks/config.yaml cfg/entpks.yaml
 

--- a/cis-benchmarks/eks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/eks/kube-bench-plugin.yaml
@@ -58,7 +58,7 @@ spec:
       value: "true"
     - name: DISTRIBUTION
       value: "eks"
-  image: sonobuoy/kube-bench:0.6.3
+  image: sonobuoy/kube-bench:v0.6.4
   name: plugin
   resources: {}
   volumeMounts:

--- a/cis-benchmarks/entpks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/entpks/kube-bench-plugin.yaml
@@ -53,7 +53,7 @@ spec:
       value: "false"
     - name: DISTRIBUTION
       value: "entpks"
-  image: sonobuoy/kube-bench:0.6.3
+  image: sonobuoy/kube-bench:v0.6.4
   name: plugin
   resources: {}
   volumeMounts:

--- a/cis-benchmarks/gke/kube-bench-plugin.yaml
+++ b/cis-benchmarks/gke/kube-bench-plugin.yaml
@@ -58,7 +58,7 @@ spec:
       value: "true"
     - name: DISTRIBUTION
       value: "gke"
-  image: sonobuoy/kube-bench:0.6.3
+  image: sonobuoy/kube-bench:v0.6.4
   name: plugin
   resources: {}
   volumeMounts:

--- a/cis-benchmarks/kube-bench-master-plugin.yaml
+++ b/cis-benchmarks/kube-bench-master-plugin.yaml
@@ -57,7 +57,7 @@ spec:
       value: "false"
     - name: TARGET_POLICIES
       value: "false"
-  image: sonobuoy/kube-bench:0.6.3
+  image: sonobuoy/kube-bench:v0.6.4
   name: plugin
   resources: {}
   volumeMounts:

--- a/cis-benchmarks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/kube-bench-plugin.yaml
@@ -57,7 +57,7 @@ spec:
       value: "false"
     - name: TARGET_POLICIES
       value: "false"
-  image: sonobuoy/kube-bench:0.6.3
+  image: sonobuoy/kube-bench:v0.6.4
   name: plugin
   resources: {}
   volumeMounts:


### PR DESCRIPTION
Note: They added the 'v' prefix since the last version so we mirror
that in our version.

Signed-off-by: John Schnake <jschnake@vmware.com>