### PR TITLE
Sonolark shouldn't filter status field

### DIFF
--- a/sonolark/lib/kube/diff.go
+++ b/sonolark/lib/kube/diff.go
@@ -89,7 +89,6 @@ func renderObj(obj runtime.Object, gvk *schema.GroupVersionKind, renderYaml bool
 	yamlMap = filterYaml(yamlMap, "metadata", "resourceVersion")
 	yamlMap = filterYaml(yamlMap, "metadata", "creationTimestamp")
 	yamlMap = filterYaml(yamlMap, "metadata", "annotations", "kubectl.kubernetes.io/last-applied-configuration")
-	yamlMap = filterYaml(yamlMap, "status")
 
 	// apply custom diff filters
 	for i := 0; i < len(diffFilters); i++ {

--- a/sonolark/lib/kube/diff_test.go
+++ b/sonolark/lib/kube/diff_test.go
@@ -87,6 +87,9 @@ func TestDiff(t *testing.T) {
 						},
 					},
 				},
+				Status: corev1.PodStatus{
+					StartTime: &now,
+				},
 			},
 			wantDiff: "",
 		},


### PR DESCRIPTION
The status field has lots of important information for different types
and shouldn't be filtered by default.

Fixes #144

Signed-off-by: John Schnake <jschnake@vmware.com>