### PR TITLE
Support more than one result file

### DIFF
--- a/post-processor/Dockerfile
+++ b/post-processor/Dockerfile
@@ -14,7 +14,6 @@ COPY go.mod /src/go.mod
 WORKDIR /src
 RUN go mod download
 
-COPY ./pkg /src/pkg
 COPY ./cmd /src/cmd
 COPY main.go /src/main.go
 RUN go build -o binary


### PR DESCRIPTION
When running e2e in parallel you end up with multiple junit files.

Signed-off-by: John Schnake <jschnake@vmware.com>