### PR TITLE
Adjust post-processor example and add another for parallel

### DIFF
--- a/post-processor/examples/changeStatus.yaml
+++ b/post-processor/examples/changeStatus.yaml
@@ -17,8 +17,6 @@ podSpec:
     - name: postprocessing
       image: schnake/postprocessor:v0
       command: ["/sonobuoy-processor"]
-#      command: ["sleep"]
-#      args: ["36000"]
   nodeSelector:
     kubernetes.io/os: linux
   restartPolicy: Never

--- a/post-processor/examples/removeSkipsAndEmptyResults.yaml
+++ b/post-processor/examples/removeSkipsAndEmptyResults.yaml
@@ -1,6 +1,7 @@
 config-map:
   ytt-transform.yaml: |
     #@ load("@ytt:overlay", "overlay")
+
     #@overlay/match by=overlay.all
     #@overlay/match-child-defaults expects="0+"
     ---
@@ -11,8 +12,28 @@ config-map:
           - items:
             #@overlay/match by=overlay.subset({"status": "skipped"})
             #@overlay/remove
-            - name: foo
-              status: skipped
+            -
+
+    #@overlay/match by=overlay.all, expects="1+"
+    ---
+    items:
+      #! file
+      #@overlay/match by=overlay.all, expects="1+"
+      -
+        items:
+        #! suite
+        #@overlay/match by=overlay.subset({"name":"Kubernetes e2e suite"}), expects="0+"
+        #@overlay/match by=lambda k,left,right: len(left["items"])==0, expects="0+"
+        #@overlay/remove
+        -
+
+    #@overlay/match by=overlay.all, expects="1+"
+    ---
+    items:
+      #! file
+      #@overlay/match by=lambda k,left,right: len(left["items"])==0, expects="0+"
+      #@overlay/remove
+      -
 podSpec:
   containers:
     - name: postprocessing
@@ -32,9 +53,9 @@ podSpec:
     operator: Exists
 sonobuoy-config:
   driver: Job
-  plugin-name: e2e-noskips
+  plugin-name: e2e-noskips-parallel
   result-format: manual
-  description: Runs a dry-run of the e2e tests. Removes all the skipped tests from the results for easier consumption.
+  description: Runs a dry-run of the e2e tests in parallel. Removes all the skipped tests and empty files/suites from the results for easier consumption.
 spec:
   command:
   - /run_e2e.sh
@@ -52,6 +73,8 @@ spec:
       patching/updating a validating webhook should work \[Conformance\]|\[sig-api-machinery\]
       AdmissionWebhook \[Privileged:ClusterAdmin\] should be able to deny attaching
       pod \[Conformance\]
+  - name: E2E_PARALLEL
+    value: "true"
   - name: E2E_USE_GO_RUNNER
     value: "true"
   - name: RESULTS_DIR


### PR DESCRIPTION
The existing 'remove skips' example currently runs in parallel but
doesn't handle that case as well as it should.

 - That example has been changed to serial tests, a simpler case.
 - A new case has been added for parallel cases where you may end
up with empty suites and files.

Signed-off-by: John Schnake <jschnake@vmware.com>