### PR TITLE
Add HTTP module to sonolark 

### DIFF
--- a/sonolark/cmd/root.go
+++ b/sonolark/cmd/root.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/util/homedir"
 
 	"github.com/k14s/starlark-go/starlark"
+	nethttp "github.com/pcj/starlark-go-nethttp"
 	"github.com/vmware-tanzu/carvel-ytt/pkg/yttlibrary"
 	"github.com/vmware-tanzu/sonobuoy-plugins/sonolark/lib/kube"
 	"k8s.io/client-go/discovery"
@@ -120,6 +121,8 @@ func getLibraryFuncs(kubeconfigPath string, currentEnv map[string]string) (*star
 		"module":  yttlibrary.ModuleAPI["module"],
 		"overlay": overlay.API["overlay"],
 		"version": yttlibrary.VersionAPI["version"],
+
+		"http": toStarlarkModule(nethttp.NewModule()),
 	}
 
 	// Custom overrides so that we can make custom error messages.

--- a/sonolark/cmd/starlarkwrapper.go
+++ b/sonolark/cmd/starlarkwrapper.go
@@ -1,0 +1,147 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/k14s/starlark-go/starlark"
+	nethttp "github.com/pcj/starlark-go-nethttp"
+	starlarkcore "go.starlark.net/starlark"
+)
+
+type Module struct {
+	netMod *nethttp.Module
+}
+
+// toYttStarlark converts the nethttp module to a ytt-starlark compatible one.
+// If we get more of these sorts of conversions, a more reusable pattern will probably
+// emerge.
+func toStarlarkModule(input *nethttp.Module) *Module {
+	return &Module{input}
+}
+
+func (mod *Module) String() string       { return "<module http>" }
+func (mod *Module) Type() string         { return "module" }
+func (mod *Module) Freeze()              { mod.netMod.Freeze() }
+func (mod *Module) Truth() starlark.Bool { return starlark.True }
+func (mod *Module) Hash() (uint32, error) {
+	return 0, fmt.Errorf("unhashable type: %s", mod.Type())
+}
+
+func (mod *Module) Attr(name string) (starlark.Value, error) {
+	val, err := mod.netMod.Attr(name)
+	if coreCallable, isCallable := val.(starlarkcore.Callable); isCallable {
+		return &yttStarlarkCallableWrapper{coreCallable}, err
+	}
+	return &yttStarlarkValueWrapper{val}, err
+}
+
+func (mod *Module) AttrNames() []string {
+	return mod.netMod.AttrNames()
+}
+
+// yttStarlarkValueWrapper wraps a type of the core starlark type but translates the Bool type so that
+// it meets the necessary interfaces for the ytt-fork of starlark.
+type yttStarlarkValueWrapper struct {
+	v starlarkcore.Value
+}
+
+func (wrapper *yttStarlarkValueWrapper) String() string { return wrapper.v.String() }
+func (wrapper *yttStarlarkValueWrapper) Type() string   { return wrapper.v.Type() }
+func (wrapper *yttStarlarkValueWrapper) Freeze()        { wrapper.v.Freeze() }
+func (wrapper *yttStarlarkValueWrapper) Truth() starlark.Bool {
+	if wrapper.v.Truth() == starlarkcore.True {
+		return starlark.True
+	}
+	return starlark.False
+}
+func (wrapper *yttStarlarkValueWrapper) Hash() (uint32, error) {
+	return wrapper.v.Hash()
+}
+
+// yttStarlarkValueWrapper wraps a type of the core starlark type but translates the Bool type so that
+// it meets the necessary interfaces for the ytt-fork of starlark.
+type yttStarlarkValueWrapperToCore struct {
+	v starlark.Value
+}
+
+func (wrapper *yttStarlarkValueWrapperToCore) String() string { return wrapper.v.String() }
+func (wrapper *yttStarlarkValueWrapperToCore) Type() string   { return wrapper.v.Type() }
+func (wrapper *yttStarlarkValueWrapperToCore) Freeze()        { wrapper.v.Freeze() }
+func (wrapper *yttStarlarkValueWrapperToCore) Truth() starlarkcore.Bool {
+	if wrapper.v.Truth() == starlark.True {
+		return starlarkcore.True
+	}
+	return starlarkcore.False
+}
+func (wrapper *yttStarlarkValueWrapperToCore) Hash() (uint32, error) {
+	return wrapper.v.Hash()
+}
+
+type yttStarlarkCallableWrapper struct {
+	v starlarkcore.Callable
+}
+
+func (wrapper *yttStarlarkCallableWrapper) Value() string { return wrapper.v.String() }
+func (wrapper *yttStarlarkCallableWrapper) Name() string  { return wrapper.v.Name() }
+func (wrapper *yttStarlarkCallableWrapper) CallInternal(
+	thread *starlark.Thread, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+
+	coreThread := starlarkcore.Thread{
+		Name: thread.Name,
+		Print: func(thread *starlarkcore.Thread, msg string) {
+			thread.Print(thread, msg)
+		},
+		Load: func(thread *starlarkcore.Thread, module string) (starlarkcore.StringDict, error) {
+			return thread.Load(thread, module)
+		},
+	}
+
+	v, err := wrapper.v.CallInternal(
+		&coreThread,
+		toCoreTuple(args),
+		toCoreTupleSlice(kwargs),
+	)
+	return &yttStarlarkValueWrapper{v}, err
+}
+
+func (wrapper *yttStarlarkCallableWrapper) String() string { return wrapper.v.String() }
+func (wrapper *yttStarlarkCallableWrapper) Type() string   { return wrapper.v.Type() }
+func (wrapper *yttStarlarkCallableWrapper) Freeze()        { wrapper.v.Freeze() }
+func (wrapper *yttStarlarkCallableWrapper) Truth() starlark.Bool {
+	if wrapper.v.Truth() == starlarkcore.True {
+		return starlark.True
+	}
+	return starlark.False
+}
+func (wrapper *yttStarlarkCallableWrapper) Hash() (uint32, error) {
+	return wrapper.v.Hash()
+}
+
+func toCoreTuple(input starlark.Tuple) starlarkcore.Tuple {
+	result := []starlarkcore.Value{}
+	for _, v := range input {
+		switch t := v.(type) {
+		case starlark.String:
+			result = append(result, starlarkcore.String(t))
+		default:
+			result = append(result, &yttStarlarkValueWrapperToCore{v})
+		}
+	}
+	return result
+}
+
+func toCoreTupleSlice(input []starlark.Tuple) []starlarkcore.Tuple {
+	result := []starlarkcore.Tuple{}
+	for _, v := range input {
+		result = append(result, toCoreTuple(v))
+	}
+	return result
+}
+
+type yttStarlarkThreadWrapper struct {
+	v starlarkcore.Thread
+}
+
+type yttStarlarkTupleWrapper struct {
+	v starlarkcore.Tuple
+}

--- a/sonolark/examples/http/script.star
+++ b/sonolark/examples/http/script.star
@@ -1,0 +1,5 @@
+print("Hello, this is an example of the http module")
+
+page = http.get(url="http://www.google.com")
+
+print(page)

--- a/sonolark/go.mod
+++ b/sonolark/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/heptio/ark v0.9.11
 	github.com/k14s/starlark-go v0.0.0-20200720175618-3a5c849cc368
 	github.com/kylelemons/godebug v1.1.0
+	github.com/pcj/starlark-go-nethttp v0.0.0-20181206163746-4f030cb7e2df
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0

--- a/sonolark/go.sum
+++ b/sonolark/go.sum
@@ -540,6 +540,8 @@ github.com/ory/dockertest v3.3.2+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnh
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
+github.com/pcj/starlark-go-nethttp v0.0.0-20181206163746-4f030cb7e2df h1:+Zer4nxvgFFAp+kwNwPnwC7fM0pEBPfveuN+ioydXkI=
+github.com/pcj/starlark-go-nethttp v0.0.0-20181206163746-4f030cb7e2df/go.mod h1:0tug9zKExfXZ6XBHR8LmKrtLUxprN02/iZ4GbUCQoxg=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=


### PR DESCRIPTION
- Incorporates a new library for http calls
 - Library uses core sonolark instead of ytt sonolark types
so a new set of types/functions made to wrap them appropriately.

 - Consider extracting out these types into their own repo in the
future since it would be of benefit to other starlark/ytt users

Fixes https://github.com/vmware-tanzu/sonobuoy-plugins/issues/141

Signed-off-by: John Schnake <jschnake@vmware.com>