### PR TITLE
kube-bench and who-can plugins results location fix

### DIFF
--- a/kube-hunter/kube-hunter-plugin.yaml
+++ b/kube-hunter/kube-hunter-plugin.yaml
@@ -6,10 +6,10 @@ spec:
   command:
   - /bin/sh
   - -c
-  - "python kube-hunter.py --pod --report=json | tee /tmp/results/report.json && echo -n /tmp/results/report.json > /tmp/results/done"
+  - "python kube-hunter.py --pod --report=json | tee $(SONOBUOY_RESULTS_DIR)/report.json && echo -n $(SONOBUOY_RESULTS_DIR)/report.json > $(SONOBUOY_RESULTS_DIR)/done"
   image: sonobuoy/kube-hunter:v0.2.0
   name: plugin
   resources: {}
   volumeMounts:
-  - mountPath: /tmp/results
+  - mountPath: $(SONOBUOY_RESULTS_DIR)
     name: results

--- a/who-can/who-can.yaml
+++ b/who-can/who-can.yaml
@@ -7,14 +7,14 @@ spec:
   - /bin/bash
   args:
   - -c
-  - /who-can --resources-report /tmp/results/resources-report.json --subjects-report /tmp/results/subjects-report.json --sonobuoy-report /tmp/results/sonobuoy_results.yaml;
-    tar czvf /tmp/results/results.tar.gz -C /tmp/results/ .;
-    echo -n /tmp/results/results.tar.gz > /tmp/results/done
+  - /who-can --resources-report $(SONOBUOY_RESULTS_DIR)/resources-report.json --subjects-report $(SONOBUOY_RESULTS_DIR)/subjects-report.json --sonobuoy-report $(SONOBUOY_RESULTS_DIR)/sonobuoy_results.yaml;
+    tar czvf $(SONOBUOY_RESULTS_DIR)/results.tar.gz -C $(SONOBUOY_RESULTS_DIR)/ .;
+    echo -n $(SONOBUOY_RESULTS_DIR)/results.tar.gz > $(SONOBUOY_RESULTS_DIR)/done
   image: sonobuoy/who-can:v0.1.1
   name: plugin
   resources: {}
   volumeMounts:
-  - mountPath: /tmp/results
+  - mountPath: $(SONOBUOY_RESULTS_DIR)
     name: results
   env:
   - name: WHO_CAN_CONFIG


### PR DESCRIPTION
`kube-bench` and `who-can` plugin definitions have the results dir set to a location which doesn't match what sonobuoy expects causing the plugin pod to go into an Error state and the sonobuoy run to never complete. Made changes to write results to expected location.