### PR TITLE
kb 0.6.9 to 0.6.10 (latest)

### DIFF
--- a/cis-benchmarks/Dockerfile
+++ b/cis-benchmarks/Dockerfile
@@ -1,4 +1,4 @@
-FROM aquasec/kube-bench:v0.6.9
+FROM aquasec/kube-bench:v0.6.10
 
 COPY entpks/config.yaml cfg/entpks.yaml
 

--- a/cis-benchmarks/eks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/eks/kube-bench-plugin.yaml
@@ -58,7 +58,7 @@ spec:
       value: "true"
     - name: DISTRIBUTION
       value: "eks"
-  image: sonobuoy/kube-bench:v0.6.9
+  image: sonobuoy/kube-bench:v0.6.10
   name: plugin
   resources: {}
   volumeMounts:

--- a/cis-benchmarks/entpks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/entpks/kube-bench-plugin.yaml
@@ -53,7 +53,7 @@ spec:
       value: "false"
     - name: DISTRIBUTION
       value: "entpks"
-  image: sonobuoy/kube-bench:v0.6.9
+  image: sonobuoy/kube-bench:v0.6.10
   name: plugin
   resources: {}
   volumeMounts:

--- a/cis-benchmarks/gke/kube-bench-plugin.yaml
+++ b/cis-benchmarks/gke/kube-bench-plugin.yaml
@@ -58,7 +58,7 @@ spec:
       value: "true"
     - name: DISTRIBUTION
       value: "gke"
-  image: sonobuoy/kube-bench:v0.6.9
+  image: sonobuoy/kube-bench:v0.6.10
   name: plugin
   resources: {}
   volumeMounts:

--- a/cis-benchmarks/kube-bench-master-plugin.yaml
+++ b/cis-benchmarks/kube-bench-master-plugin.yaml
@@ -57,7 +57,7 @@ spec:
       value: "false"
     - name: TARGET_POLICIES
       value: "false"
-  image: sonobuoy/kube-bench:v0.6.9
+  image: sonobuoy/kube-bench:v0.6.10
   name: plugin
   resources: {}
   volumeMounts:

--- a/cis-benchmarks/kube-bench-plugin.yaml
+++ b/cis-benchmarks/kube-bench-plugin.yaml
@@ -57,7 +57,7 @@ spec:
       value: "false"
     - name: TARGET_POLICIES
       value: "false"
-  image: sonobuoy/kube-bench:v0.6.9
+  image: sonobuoy/kube-bench:v0.6.10
   name: plugin
   resources: {}
   volumeMounts:


### PR DESCRIPTION
OSSPI caught more CVEs on KB 0.6.9, moving to latest (0.6.10) to hopefully clear those up. 